### PR TITLE
Fix: Update /$ref update operation from PATCH to PUT

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 {OperationType.Delete, new NavigationPropertyDeleteOperationHandler() }
             };
 
-            // navigati0n property ref (Get/Post/Put/Delete)
+            // navigation property ref (Get/Post/Put/Delete)
             _handlers[ODataPathKind.Ref] = new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new RefGetOperationHandler() },

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -68,11 +68,11 @@ namespace Microsoft.OpenApi.OData.Operation
                 {OperationType.Delete, new NavigationPropertyDeleteOperationHandler() }
             };
 
-            // navigatoin property ref (Get/Post/Patch/Delete)
+            // navigati0n property ref (Get/Post/Put/Delete)
             _handlers[ODataPathKind.Ref] = new Dictionary<OperationType, IOperationHandler>
             {
                 {OperationType.Get, new RefGetOperationHandler() },
-                {OperationType.Patch, new RefPatchOperationHandler() },
+                {OperationType.Put, new RefPutOperationHandler() },
                 {OperationType.Post, new RefPostOperationHandler() },
                 {OperationType.Delete, new RefDeleteOperationHandler() }
             };

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
@@ -67,8 +67,7 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             OpenApiSchema schema = new OpenApiSchema
             {
-                Type = "object",
-                AdditionalProperties = new OpenApiSchema { Type = "object" }
+                Type = "string"
             };
 
             operation.Responses = new OpenApiResponses

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
@@ -67,7 +67,8 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             OpenApiSchema schema = new OpenApiSchema
             {
-                Type = "object" // What to return?
+                Type = "object",
+                AdditionalProperties = new OpenApiSchema { Type = "object" }
             };
 
             operation.Responses = new OpenApiResponses

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             OpenApiSchema schema = new OpenApiSchema
             {
-                Type = "string"
+                Type = "object"
             };
 
             operation.Responses = new OpenApiResponses

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             OpenApiSchema schema = new OpenApiSchema
             {
-                Type = "String"
+                Type = "object"
             };
 
             operation.RequestBody = new OpenApiRequestBody
@@ -66,7 +66,7 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             OpenApiSchema schema = new OpenApiSchema
             {
-                Type = "String" // What to return?
+                Type = "object" // What to return?
             };
 
             operation.Responses = new OpenApiResponses

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPostOperationHandler.cs
@@ -40,7 +40,8 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             OpenApiSchema schema = new OpenApiSchema
             {
-                Type = "object"
+                Type = "object",
+                AdditionalProperties = new OpenApiSchema { Type = "object" }
             };
 
             operation.RequestBody = new OpenApiRequestBody

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OpenApi.OData.Operation
     /// <summary>
     /// Update a navigation property ref for a navigation source.
     /// </summary>
-    internal class RefPatchOperationHandler : NavigationPropertyOperationHandler
+    internal class RefPutOperationHandler : NavigationPropertyOperationHandler
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Patch;
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             OpenApiSchema schema = new OpenApiSchema
             {
-                Type = "String"
+                Type = "object"
             };
 
             operation.RequestBody = new OpenApiRequestBody

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/RefPutOperationHandler.cs
@@ -40,7 +40,8 @@ namespace Microsoft.OpenApi.OData.Operation
         {
             OpenApiSchema schema = new OpenApiSchema
             {
-                Type = "object"
+                Type = "object",
+                AdditionalProperties = new OpenApiSchema { Type = "object" }
             };
 
             operation.RequestBody = new OpenApiRequestBody

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandler.cs
@@ -80,7 +80,7 @@ namespace Microsoft.OpenApi.OData.PathItem
         /// Add one operation into path item.
         /// </summary>
         /// <param name="item">The path item.</param>
-        /// <param name="operationType">The operatin type.</param>
+        /// <param name="operationType">The operation type.</param>
         protected virtual void AddOperation(OpenApiPathItem item, OperationType operationType)
         {
             IOperationHandlerProvider provider = Context.OperationHanderProvider;

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/RefPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/RefPathItemHandler.cs
@@ -90,7 +90,7 @@ namespace Microsoft.OpenApi.OData.PathItem
                 UpdateRestrictionsType update = restriction?.UpdateRestrictions;
                 if (update == null || update.IsUpdatable)
                 {
-                    AddOperation(item, OperationType.Patch);
+                    AddOperation(item, OperationType.Put);
                 }
             }
 

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/RefPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/RefPathItemHandler.cs
@@ -92,13 +92,13 @@ namespace Microsoft.OpenApi.OData.PathItem
                 {
                     AddOperation(item, OperationType.Put);
                 }
-            }
 
-            // delete the link
-            DeleteRestrictionsType delete = restriction?.DeleteRestrictions;
-            if (delete == null || delete.IsDeletable)
-            {
-                AddOperation(item, OperationType.Delete);
+                // delete the link
+                DeleteRestrictionsType delete = restriction?.DeleteRestrictions;
+                if (delete == null || delete.IsDeletable)
+                {
+                    AddOperation(item, OperationType.Delete);
+                }
             }
         }
 

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/OperationHandlerProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/OperationHandlerProviderTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         [InlineData(ODataPathKind.Ref, OperationType.Post, typeof(RefPostOperationHandler))]
         [InlineData(ODataPathKind.Ref, OperationType.Delete, typeof(RefDeleteOperationHandler))]
         [InlineData(ODataPathKind.Ref, OperationType.Get, typeof(RefGetOperationHandler))]
-        [InlineData(ODataPathKind.Ref, OperationType.Patch, typeof(RefPatchOperationHandler))]
+        [InlineData(ODataPathKind.Ref, OperationType.Put, typeof(RefPutOperationHandler))]
         public void GetHandlerReturnsCorrectOperationHandlerType(ODataPathKind pathKind, OperationType operationType, Type handlerType)
         {
             // Arrange

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/RefPutOperationHandlerTests.cs
@@ -4,23 +4,21 @@
 // ------------------------------------------------------------
 
 using Microsoft.OData.Edm;
-using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.OData.Edm;
-using Microsoft.OpenApi.OData.PathItem.Tests;
 using Microsoft.OpenApi.OData.Tests;
 using System.Linq;
 using Xunit;
 
 namespace Microsoft.OpenApi.OData.Operation.Tests
 {
-    public class RefPatchOperationHandlerTests
+    public class RefPutOperationHandlerTests
     {
-        private RefPatchOperationHandler _operationHandler = new RefPatchOperationHandler();
+        private RefPutOperationHandler _operationHandler = new RefPutOperationHandler();
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void CreateNavigationRefPatchOperationReturnsCorrectOperation(bool enableOperationId)
+        public void CreateNavigationRefPutOperationReturnsCorrectOperation(bool enableOperationId)
         {
             // Arrange
             IEdmModel model = EdmModelHelper.TripServiceModel;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/RefPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/RefPathItemHandlerTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         }
 
         [Theory]
-        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Post, OperationType.Delete })]
+        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Post})]
         [InlineData(false, new OperationType[] { OperationType.Get, OperationType.Put, OperationType.Delete })]
         public void CreateNavigationPropertyRefPathItemReturnsCorrectPathItem(bool collectionNav, OperationType[] expected)
         {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/RefPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/RefPathItemHandlerTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
 
         [Theory]
         [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Post, OperationType.Delete })]
-        [InlineData(false, new OperationType[] { OperationType.Get, OperationType.Patch, OperationType.Delete })]
+        [InlineData(false, new OperationType[] { OperationType.Get, OperationType.Put, OperationType.Delete })]
         public void CreateNavigationPropertyRefPathItemReturnsCorrectPathItem(bool collectionNav, OperationType[] expected)
         {
             // Arrange

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -998,7 +998,10 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],
@@ -1666,7 +1669,10 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],
@@ -2190,7 +2196,10 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],
@@ -2949,7 +2958,10 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -1009,10 +1009,7 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "type": "object"
             }
           },
           "default": {
@@ -1683,10 +1680,7 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "type": "object"
             }
           },
           "default": {
@@ -2975,10 +2969,7 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "type": "object"
             }
           },
           "default": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -2245,7 +2245,7 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "patch": {
+      "put": {
         "tags": [
           "Revisions.Document"
         ],
@@ -2272,7 +2272,7 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -1009,7 +1009,10 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           },
           "default": {
@@ -1680,7 +1683,10 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           },
           "default": {
@@ -2969,7 +2975,10 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           },
           "default": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.json
@@ -998,7 +998,7 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],
@@ -1006,49 +1006,8 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "String"
+              "type": "object"
             }
-          },
-          "default": {
-            "$ref": "#/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "Documents.RevisionDto"
-        ],
-        "summary": "Delete ref of navigation property Revisions for Documents",
-        "operationId": "Documents.DeleteRefRevisions",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "Id",
-            "description": "key: Id of DocumentDto",
-            "required": true,
-            "type": "integer",
-            "format": "int32",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "x-ms-docs-key-type": "DocumentDto"
-          },
-          {
-            "in": "header",
-            "name": "If-Match",
-            "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/responses/error"
@@ -1707,7 +1666,7 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],
@@ -1715,49 +1674,8 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "String"
+              "type": "object"
             }
-          },
-          "default": {
-            "$ref": "#/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "Libraries.DocumentDto"
-        ],
-        "summary": "Delete ref of navigation property Documents for Libraries",
-        "operationId": "Libraries.DeleteRefDocuments",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "Id",
-            "description": "key: Id of LibraryDto",
-            "required": true,
-            "type": "integer",
-            "format": "int32",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "x-ms-docs-key-type": "LibraryDto"
-          },
-          {
-            "in": "header",
-            "name": "If-Match",
-            "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/responses/error"
@@ -3031,7 +2949,7 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],
@@ -3039,49 +2957,8 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "String"
+              "type": "object"
             }
-          },
-          "default": {
-            "$ref": "#/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "Tasks.RevisionDto"
-        ],
-        "summary": "Delete ref of navigation property Revisions for Tasks",
-        "operationId": "Tasks.DeleteRefRevisions",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "Id",
-            "description": "key: Id of DocumentDto",
-            "required": true,
-            "type": "integer",
-            "format": "int32",
-            "maximum": 2147483647,
-            "minimum": -2147483648,
-            "x-ms-docs-key-type": "DocumentDto"
-          },
-          {
-            "in": "header",
-            "name": "If-Match",
-            "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/responses/error"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -1632,7 +1632,7 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
+    put:
       tags:
         - Revisions.Document
       summary: Update the ref of navigation property Document in Revisions
@@ -1654,7 +1654,7 @@ paths:
           description: New navigation property ref values
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '204':
           description: Success

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -728,8 +728,6 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
-            additionalProperties:
-              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -1214,8 +1212,6 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
-            additionalProperties:
-              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -2167,8 +2163,6 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
-            additionalProperties:
-              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -728,6 +728,8 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
+            additionalProperties:
+              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -1212,6 +1214,8 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
+            additionalProperties:
+              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -2163,6 +2167,8 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
+            additionalProperties:
+              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -721,6 +721,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '201':
           description: Created navigation property link.
@@ -1203,6 +1205,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '201':
           description: Created navigation property link.
@@ -1597,6 +1601,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '204':
           description: Success
@@ -2150,6 +2156,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '201':
           description: Created navigation property link.

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.V2.yaml
@@ -720,41 +720,12 @@ paths:
           description: New navigation property ref value
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '201':
           description: Created navigation property link.
           schema:
-            type: String
-        default:
-          $ref: '#/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - Documents.RevisionDto
-      summary: Delete ref of navigation property Revisions for Documents
-      operationId: Documents.DeleteRefRevisions
-      parameters:
-        - in: path
-          name: Id
-          description: 'key: Id of DocumentDto'
-          required: true
-          type: integer
-          format: int32
-          maximum: 2147483647
-          minimum: -2147483648
-          x-ms-docs-key-type: DocumentDto
-        - in: header
-          name: If-Match
-          description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
-      responses:
-        '204':
-          description: Success
+            type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -1231,41 +1202,12 @@ paths:
           description: New navigation property ref value
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '201':
           description: Created navigation property link.
           schema:
-            type: String
-        default:
-          $ref: '#/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - Libraries.DocumentDto
-      summary: Delete ref of navigation property Documents for Libraries
-      operationId: Libraries.DeleteRefDocuments
-      parameters:
-        - in: path
-          name: Id
-          description: 'key: Id of LibraryDto'
-          required: true
-          type: integer
-          format: int32
-          maximum: 2147483647
-          minimum: -2147483648
-          x-ms-docs-key-type: LibraryDto
-        - in: header
-          name: If-Match
-          description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
-      responses:
-        '204':
-          description: Success
+            type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -2207,41 +2149,12 @@ paths:
           description: New navigation property ref value
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '201':
           description: Created navigation property link.
           schema:
-            type: String
-        default:
-          $ref: '#/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - Tasks.RevisionDto
-      summary: Delete ref of navigation property Revisions for Tasks
-      operationId: Tasks.DeleteRefRevisions
-      parameters:
-        - in: path
-          name: Id
-          description: 'key: Id of DocumentDto'
-          required: true
-          type: integer
-          format: int32
-          maximum: 2147483647
-          minimum: -2147483648
-          x-ms-docs-key-type: DocumentDto
-        - in: header
-          name: If-Match
-          description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
-      responses:
-        '204':
-          description: Success
+            type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -1120,7 +1120,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -1880,7 +1883,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -2529,7 +2535,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -3383,7 +3392,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -1120,7 +1120,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },
@@ -1132,57 +1132,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "object"
                 }
               }
             }
-          },
-          "default": {
-            "$ref": "#/components/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "Documents.RevisionDto"
-        ],
-        "summary": "Delete ref of navigation property Revisions for Documents",
-        "operationId": "Documents.DeleteRefRevisions",
-        "parameters": [
-          {
-            "name": "Id",
-            "in": "path",
-            "description": "key: Id of DocumentDto",
-            "required": true,
-            "schema": {
-              "maximum": 2147483647,
-              "minimum": -2147483648,
-              "type": "integer",
-              "format": "int32"
-            },
-            "x-ms-docs-key-type": "DocumentDto"
-          },
-          {
-            "name": "If-Match",
-            "in": "header",
-            "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"
@@ -1927,7 +1880,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },
@@ -1939,57 +1892,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "object"
                 }
               }
             }
-          },
-          "default": {
-            "$ref": "#/components/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "Libraries.DocumentDto"
-        ],
-        "summary": "Delete ref of navigation property Documents for Libraries",
-        "operationId": "Libraries.DeleteRefDocuments",
-        "parameters": [
-          {
-            "name": "Id",
-            "in": "path",
-            "description": "key: Id of LibraryDto",
-            "required": true,
-            "schema": {
-              "maximum": 2147483647,
-              "minimum": -2147483648,
-              "type": "integer",
-              "format": "int32"
-            },
-            "x-ms-docs-key-type": "LibraryDto"
-          },
-          {
-            "name": "If-Match",
-            "in": "header",
-            "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"
@@ -3477,7 +3383,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },
@@ -3489,57 +3395,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "object"
                 }
               }
             }
-          },
-          "default": {
-            "$ref": "#/components/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "Tasks.RevisionDto"
-        ],
-        "summary": "Delete ref of navigation property Revisions for Tasks",
-        "operationId": "Tasks.DeleteRefRevisions",
-        "parameters": [
-          {
-            "name": "Id",
-            "in": "path",
-            "description": "key: Id of DocumentDto",
-            "required": true,
-            "schema": {
-              "maximum": 2147483647,
-              "minimum": -2147483648,
-              "type": "integer",
-              "format": "int32"
-            },
-            "x-ms-docs-key-type": "DocumentDto"
-          },
-          {
-            "name": "If-Match",
-            "in": "header",
-            "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -2597,7 +2597,7 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "patch": {
+      "put": {
         "tags": [
           "Revisions.Document"
         ],
@@ -2623,7 +2623,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -1135,7 +1135,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
                 }
               }
             }
@@ -1898,7 +1901,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
                 }
               }
             }
@@ -3407,7 +3413,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
                 }
               }
             }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.json
@@ -1135,10 +1135,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object"
-                  }
+                  "type": "object"
                 }
               }
             }
@@ -1901,10 +1898,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object"
-                  }
+                  "type": "object"
                 }
               }
             }
@@ -3413,10 +3407,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object"
-                  }
+                  "type": "object"
                 }
               }
             }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -809,8 +809,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties:
-                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -1355,8 +1353,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties:
-                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -2449,8 +2445,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties:
-                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -799,6 +799,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '201':
@@ -1341,6 +1343,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '201':
@@ -1815,6 +1819,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '204':
@@ -2429,6 +2435,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '201':

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -798,7 +798,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '201':
@@ -806,39 +806,7 @@ paths:
           content:
             application/json:
               schema:
-                type: String
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - Documents.RevisionDto
-      summary: Delete ref of navigation property Revisions for Documents
-      operationId: Documents.DeleteRefRevisions
-      parameters:
-        - name: Id
-          in: path
-          description: 'key: Id of DocumentDto'
-          required: true
-          schema:
-            maximum: 2147483647
-            minimum: -2147483648
-            type: integer
-            format: int32
-          x-ms-docs-key-type: DocumentDto
-        - name: If-Match
-          in: header
-          description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
-      responses:
-        '204':
-          description: Success
+                type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -1372,7 +1340,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '201':
@@ -1380,39 +1348,7 @@ paths:
           content:
             application/json:
               schema:
-                type: String
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - Libraries.DocumentDto
-      summary: Delete ref of navigation property Documents for Libraries
-      operationId: Libraries.DeleteRefDocuments
-      parameters:
-        - name: Id
-          in: path
-          description: 'key: Id of LibraryDto'
-          required: true
-          schema:
-            maximum: 2147483647
-            minimum: -2147483648
-            type: integer
-            format: int32
-          x-ms-docs-key-type: LibraryDto
-        - name: If-Match
-          in: header
-          description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
-      responses:
-        '204':
-          description: Success
+                type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -2492,7 +2428,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '201':
@@ -2500,39 +2436,7 @@ paths:
           content:
             application/json:
               schema:
-                type: String
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - Tasks.RevisionDto
-      summary: Delete ref of navigation property Revisions for Tasks
-      operationId: Tasks.DeleteRefRevisions
-      parameters:
-        - name: Id
-          in: path
-          description: 'key: Id of DocumentDto'
-          required: true
-          schema:
-            maximum: 2147483647
-            minimum: -2147483648
-            type: integer
-            format: int32
-          x-ms-docs-key-type: DocumentDto
-        - name: If-Match
-          in: header
-          description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
-      responses:
-        '204':
-          description: Success
+                type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -1857,7 +1857,7 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
+    put:
       tags:
         - Revisions.Document
       summary: Update the ref of navigation property Document in Revisions
@@ -1878,7 +1878,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '204':

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/Multiple.Schema.OpenApi.yaml
@@ -809,6 +809,8 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -1353,6 +1355,8 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -2445,6 +2449,8 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1141,7 +1141,10 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           },
           "default": {
@@ -1664,7 +1667,10 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           },
           "default": {
@@ -2498,7 +2504,10 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           },
           "default": {
@@ -3103,7 +3112,10 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           },
           "default": {
@@ -3937,7 +3949,10 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           },
           "default": {
@@ -4542,7 +4557,10 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           },
           "default": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1127,7 +1127,7 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],
@@ -1135,38 +1135,8 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "String"
+              "type": "object"
             }
-          },
-          "default": {
-            "$ref": "#/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "Me.Person"
-        ],
-        "summary": "Delete ref of navigation property Friends for Me",
-        "operationId": "Me.DeleteRefFriends",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "If-Match",
-            "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/responses/error"
@@ -1677,7 +1647,7 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],
@@ -1685,38 +1655,8 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "String"
+              "type": "object"
             }
-          },
-          "default": {
-            "$ref": "#/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "Me.Trip"
-        ],
-        "summary": "Delete ref of navigation property Trips for Me",
-        "operationId": "Me.DeleteRefTrips",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "If-Match",
-            "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/responses/error"
@@ -2535,7 +2475,7 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],
@@ -2543,46 +2483,8 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "String"
+              "type": "object"
             }
-          },
-          "default": {
-            "$ref": "#/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "NewComePeople.Person"
-        ],
-        "summary": "Delete ref of navigation property Friends for NewComePeople",
-        "operationId": "NewComePeople.DeleteRefFriends",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "UserName",
-            "description": "key: UserName of Person",
-            "required": true,
-            "type": "string",
-            "x-ms-docs-key-type": "Person"
-          },
-          {
-            "in": "header",
-            "name": "If-Match",
-            "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/responses/error"
@@ -3175,7 +3077,7 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],
@@ -3183,46 +3085,8 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "String"
+              "type": "object"
             }
-          },
-          "default": {
-            "$ref": "#/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "NewComePeople.Trip"
-        ],
-        "summary": "Delete ref of navigation property Trips for NewComePeople",
-        "operationId": "NewComePeople.DeleteRefTrips",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "UserName",
-            "description": "key: UserName of Person",
-            "required": true,
-            "type": "string",
-            "x-ms-docs-key-type": "Person"
-          },
-          {
-            "in": "header",
-            "name": "If-Match",
-            "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/responses/error"
@@ -4041,7 +3905,7 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],
@@ -4049,46 +3913,8 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "String"
+              "type": "object"
             }
-          },
-          "default": {
-            "$ref": "#/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "People.Person"
-        ],
-        "summary": "Delete ref of navigation property Friends for People",
-        "operationId": "People.DeleteRefFriends",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "UserName",
-            "description": "key: UserName of Person",
-            "required": true,
-            "type": "string",
-            "x-ms-docs-key-type": "Person"
-          },
-          {
-            "in": "header",
-            "name": "If-Match",
-            "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/responses/error"
@@ -4681,7 +4507,7 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],
@@ -4689,46 +4515,8 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "String"
+              "type": "object"
             }
-          },
-          "default": {
-            "$ref": "#/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "People.Trip"
-        ],
-        "summary": "Delete ref of navigation property Trips for People",
-        "operationId": "People.DeleteRefTrips",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "UserName",
-            "description": "key: UserName of Person",
-            "required": true,
-            "type": "string",
-            "x-ms-docs-key-type": "Person"
-          },
-          {
-            "in": "header",
-            "name": "If-Match",
-            "description": "ETag",
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "@id",
-            "description": "Delete Uri",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/responses/error"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -774,7 +774,7 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "patch": {
+      "put": {
         "tags": [
           "Me.Person"
         ],
@@ -790,7 +790,7 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],
@@ -2134,7 +2134,7 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "patch": {
+      "put": {
         "tags": [
           "NewComePeople.Person"
         ],
@@ -2158,7 +2158,7 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],
@@ -3640,7 +3640,7 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "patch": {
+      "put": {
         "tags": [
           "People.Person"
         ],
@@ -3664,7 +3664,7 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "object"
             }
           }
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -1141,10 +1141,7 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "type": "object"
             }
           },
           "default": {
@@ -1667,10 +1664,7 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "type": "object"
             }
           },
           "default": {
@@ -2504,10 +2498,7 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "type": "object"
             }
           },
           "default": {
@@ -3112,10 +3103,7 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "type": "object"
             }
           },
           "default": {
@@ -3949,10 +3937,7 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "type": "object"
             }
           },
           "default": {
@@ -4557,10 +4542,7 @@
           "201": {
             "description": "Created navigation property link.",
             "schema": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "object"
-              }
+              "type": "object"
             }
           },
           "default": {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.json
@@ -790,7 +790,10 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],
@@ -1127,7 +1130,10 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],
@@ -1647,7 +1653,10 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],
@@ -2098,7 +2107,10 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],
@@ -2475,7 +2487,10 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],
@@ -3077,7 +3092,10 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],
@@ -3528,7 +3546,10 @@
             "description": "New navigation property ref values",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],
@@ -3905,7 +3926,10 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],
@@ -4507,7 +4531,10 @@
             "description": "New navigation property ref value",
             "required": true,
             "schema": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           }
         ],

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -787,6 +787,8 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
+            additionalProperties:
+              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -1144,6 +1146,8 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
+            additionalProperties:
+              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -1738,6 +1742,8 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
+            additionalProperties:
+              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -2156,6 +2162,8 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
+            additionalProperties:
+              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -2750,6 +2758,8 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
+            additionalProperties:
+              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -3168,6 +3178,8 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
+            additionalProperties:
+              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -787,8 +787,6 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
-            additionalProperties:
-              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -1146,8 +1144,6 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
-            additionalProperties:
-              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -1742,8 +1738,6 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
-            additionalProperties:
-              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -2162,8 +2156,6 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
-            additionalProperties:
-              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -2758,8 +2750,6 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
-            additionalProperties:
-              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -3178,8 +3168,6 @@ paths:
           description: Created navigation property link.
           schema:
             type: object
-            additionalProperties:
-              type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -525,7 +525,7 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
+    put:
       tags:
         - Me.Person
       summary: Update the ref of navigation property BestFriend in Me
@@ -538,7 +538,7 @@ paths:
           description: New navigation property ref values
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '204':
           description: Success
@@ -1474,7 +1474,7 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
+    put:
       tags:
         - NewComePeople.Person
       summary: Update the ref of navigation property BestFriend in NewComePeople
@@ -1493,7 +1493,7 @@ paths:
           description: New navigation property ref values
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '204':
           description: Success
@@ -2532,7 +2532,7 @@ paths:
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
+    put:
       tags:
         - People.Person
       summary: Update the ref of navigation property BestFriend in People
@@ -2551,7 +2551,7 @@ paths:
           description: New navigation property ref values
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '204':
           description: Success

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -777,32 +777,12 @@ paths:
           description: New navigation property ref value
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '201':
           description: Created navigation property link.
           schema:
-            type: String
-        default:
-          $ref: '#/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - Me.Person
-      summary: Delete ref of navigation property Friends for Me
-      operationId: Me.DeleteRefFriends
-      parameters:
-        - in: header
-          name: If-Match
-          description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
-      responses:
-        '204':
-          description: Success
+            type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -1152,32 +1132,12 @@ paths:
           description: New navigation property ref value
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '201':
           description: Created navigation property link.
           schema:
-            type: String
-        default:
-          $ref: '#/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - Me.Trip
-      summary: Delete ref of navigation property Trips for Me
-      operationId: Me.DeleteRefTrips
-      parameters:
-        - in: header
-          name: If-Match
-          description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
-      responses:
-        '204':
-          description: Success
+            type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -1762,38 +1722,12 @@ paths:
           description: New navigation property ref value
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '201':
           description: Created navigation property link.
           schema:
-            type: String
-        default:
-          $ref: '#/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - NewComePeople.Person
-      summary: Delete ref of navigation property Friends for NewComePeople
-      operationId: NewComePeople.DeleteRefFriends
-      parameters:
-        - in: path
-          name: UserName
-          description: 'key: UserName of Person'
-          required: true
-          type: string
-          x-ms-docs-key-type: Person
-        - in: header
-          name: If-Match
-          description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
-      responses:
-        '204':
-          description: Success
+            type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -2204,38 +2138,12 @@ paths:
           description: New navigation property ref value
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '201':
           description: Created navigation property link.
           schema:
-            type: String
-        default:
-          $ref: '#/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - NewComePeople.Trip
-      summary: Delete ref of navigation property Trips for NewComePeople
-      operationId: NewComePeople.DeleteRefTrips
-      parameters:
-        - in: path
-          name: UserName
-          description: 'key: UserName of Person'
-          required: true
-          type: string
-          x-ms-docs-key-type: Person
-        - in: header
-          name: If-Match
-          description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
-      responses:
-        '204':
-          description: Success
+            type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -2820,38 +2728,12 @@ paths:
           description: New navigation property ref value
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '201':
           description: Created navigation property link.
           schema:
-            type: String
-        default:
-          $ref: '#/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - People.Person
-      summary: Delete ref of navigation property Friends for People
-      operationId: People.DeleteRefFriends
-      parameters:
-        - in: path
-          name: UserName
-          description: 'key: UserName of Person'
-          required: true
-          type: string
-          x-ms-docs-key-type: Person
-        - in: header
-          name: If-Match
-          description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
-      responses:
-        '204':
-          description: Success
+            type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation
@@ -3262,38 +3144,12 @@ paths:
           description: New navigation property ref value
           required: true
           schema:
-            type: String
+            type: object
       responses:
         '201':
           description: Created navigation property link.
           schema:
-            type: String
-        default:
-          $ref: '#/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - People.Trip
-      summary: Delete ref of navigation property Trips for People
-      operationId: People.DeleteRefTrips
-      parameters:
-        - in: path
-          name: UserName
-          description: 'key: UserName of Person'
-          required: true
-          type: string
-          x-ms-docs-key-type: Person
-        - in: header
-          name: If-Match
-          description: ETag
-          type: string
-        - in: query
-          name: '@id'
-          description: Delete Uri
-          type: string
-      responses:
-        '204':
-          description: Success
+            type: object
         default:
           $ref: '#/responses/error'
       x-ms-docs-operation-type: operation

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.V2.yaml
@@ -539,6 +539,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '204':
           description: Success
@@ -778,6 +780,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '201':
           description: Created navigation property link.
@@ -1133,6 +1137,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '201':
           description: Created navigation property link.
@@ -1454,6 +1460,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '204':
           description: Success
@@ -1723,6 +1731,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '201':
           description: Created navigation property link.
@@ -2139,6 +2149,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '201':
           description: Created navigation property link.
@@ -2460,6 +2472,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '204':
           description: Success
@@ -2729,6 +2743,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '201':
           description: Created navigation property link.
@@ -3145,6 +3161,8 @@ paths:
           required: true
           schema:
             type: object
+            additionalProperties:
+              type: object
       responses:
         '201':
           description: Created navigation property link.

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1301,7 +1301,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
                 }
               }
             }
@@ -1882,7 +1885,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
                 }
               }
             }
@@ -2812,7 +2818,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
                 }
               }
             }
@@ -3501,7 +3510,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
                 }
               }
             }
@@ -4431,7 +4443,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
                 }
               }
             }
@@ -5120,7 +5135,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
                 }
               }
             }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -915,7 +915,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -1283,7 +1286,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -1861,7 +1867,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -2365,7 +2374,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -2785,7 +2797,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -3471,7 +3486,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -3975,7 +3993,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -4395,7 +4416,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },
@@ -5081,7 +5105,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
               }
             }
           },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1301,10 +1301,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object"
-                  }
+                  "type": "object"
                 }
               }
             }
@@ -1885,10 +1882,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object"
-                  }
+                  "type": "object"
                 }
               }
             }
@@ -2818,10 +2812,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object"
-                  }
+                  "type": "object"
                 }
               }
             }
@@ -3510,10 +3501,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object"
-                  }
+                  "type": "object"
                 }
               }
             }
@@ -4443,10 +4431,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object"
-                  }
+                  "type": "object"
                 }
               }
             }
@@ -5135,10 +5120,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "object"
-                  }
+                  "type": "object"
                 }
               }
             }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -904,7 +904,7 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "patch": {
+      "put": {
         "tags": [
           "Me.Person"
         ],
@@ -915,7 +915,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },
@@ -2410,7 +2410,7 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "patch": {
+      "put": {
         "tags": [
           "NewComePeople.Person"
         ],
@@ -2433,7 +2433,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },
@@ -4108,7 +4108,7 @@
         },
         "x-ms-docs-operation-type": "operation"
       },
-      "patch": {
+      "put": {
         "tags": [
           "People.Person"
         ],
@@ -4131,7 +4131,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.json
@@ -1283,7 +1283,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },
@@ -1295,44 +1295,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "object"
                 }
               }
             }
-          },
-          "default": {
-            "$ref": "#/components/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "Me.Person"
-        ],
-        "summary": "Delete ref of navigation property Friends for Me",
-        "operationId": "Me.DeleteRefFriends",
-        "parameters": [
-          {
-            "name": "If-Match",
-            "in": "header",
-            "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"
@@ -1895,7 +1861,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },
@@ -1907,44 +1873,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "object"
                 }
               }
             }
-          },
-          "default": {
-            "$ref": "#/components/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "Me.Trip"
-        ],
-        "summary": "Delete ref of navigation property Trips for Me",
-        "operationId": "Me.DeleteRefTrips",
-        "parameters": [
-          {
-            "name": "If-Match",
-            "in": "header",
-            "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"
@@ -2853,7 +2785,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },
@@ -2865,54 +2797,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "object"
                 }
               }
             }
-          },
-          "default": {
-            "$ref": "#/components/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "NewComePeople.Person"
-        ],
-        "summary": "Delete ref of navigation property Friends for NewComePeople",
-        "operationId": "NewComePeople.DeleteRefFriends",
-        "parameters": [
-          {
-            "name": "UserName",
-            "in": "path",
-            "description": "key: UserName of Person",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "x-ms-docs-key-type": "Person"
-          },
-          {
-            "name": "If-Match",
-            "in": "header",
-            "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"
@@ -3583,7 +3471,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },
@@ -3595,54 +3483,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "object"
                 }
               }
             }
-          },
-          "default": {
-            "$ref": "#/components/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "NewComePeople.Trip"
-        ],
-        "summary": "Delete ref of navigation property Trips for NewComePeople",
-        "operationId": "NewComePeople.DeleteRefTrips",
-        "parameters": [
-          {
-            "name": "UserName",
-            "in": "path",
-            "description": "key: UserName of Person",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "x-ms-docs-key-type": "Person"
-          },
-          {
-            "name": "If-Match",
-            "in": "header",
-            "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"
@@ -4551,7 +4395,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },
@@ -4563,54 +4407,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "object"
                 }
               }
             }
-          },
-          "default": {
-            "$ref": "#/components/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "People.Person"
-        ],
-        "summary": "Delete ref of navigation property Friends for People",
-        "operationId": "People.DeleteRefFriends",
-        "parameters": [
-          {
-            "name": "UserName",
-            "in": "path",
-            "description": "key: UserName of Person",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "x-ms-docs-key-type": "Person"
-          },
-          {
-            "name": "If-Match",
-            "in": "header",
-            "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"
@@ -5281,7 +5081,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "String"
+                "type": "object"
               }
             }
           },
@@ -5293,54 +5093,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "String"
+                  "type": "object"
                 }
               }
             }
-          },
-          "default": {
-            "$ref": "#/components/responses/error"
-          }
-        },
-        "x-ms-docs-operation-type": "operation"
-      },
-      "delete": {
-        "tags": [
-          "People.Trip"
-        ],
-        "summary": "Delete ref of navigation property Trips for People",
-        "operationId": "People.DeleteRefTrips",
-        "parameters": [
-          {
-            "name": "UserName",
-            "in": "path",
-            "description": "key: UserName of Person",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "x-ms-docs-key-type": "Person"
-          },
-          {
-            "name": "If-Match",
-            "in": "header",
-            "description": "ETag",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "@id",
-            "in": "query",
-            "description": "Delete Uri",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Success"
           },
           "default": {
             "$ref": "#/components/responses/error"

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -599,7 +599,7 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
+    put:
       tags:
         - Me.Person
       summary: Update the ref of navigation property BestFriend in Me
@@ -609,7 +609,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '204':
@@ -1635,7 +1635,7 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
+    put:
       tags:
         - NewComePeople.Person
       summary: Update the ref of navigation property BestFriend in NewComePeople
@@ -1653,7 +1653,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '204':
@@ -2803,7 +2803,7 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
-    patch:
+    put:
       tags:
         - People.Person
       summary: Update the ref of navigation property BestFriend in People
@@ -2821,7 +2821,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '204':

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -870,7 +870,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '201':
@@ -878,29 +878,7 @@ paths:
           content:
             application/json:
               schema:
-                type: String
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - Me.Person
-      summary: Delete ref of navigation property Friends for Me
-      operationId: Me.DeleteRefFriends
-      parameters:
-        - name: If-Match
-          in: header
-          description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
-      responses:
-        '204':
-          description: Success
+                type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -1277,7 +1255,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '201':
@@ -1285,29 +1263,7 @@ paths:
           content:
             application/json:
               schema:
-                type: String
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - Me.Trip
-      summary: Delete ref of navigation property Trips for Me
-      operationId: Me.DeleteRefTrips
-      parameters:
-        - name: If-Match
-          in: header
-          description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
-      responses:
-        '204':
-          description: Success
+                type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -1950,7 +1906,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '201':
@@ -1958,36 +1914,7 @@ paths:
           content:
             application/json:
               schema:
-                type: String
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - NewComePeople.Person
-      summary: Delete ref of navigation property Friends for NewComePeople
-      operationId: NewComePeople.DeleteRefFriends
-      parameters:
-        - name: UserName
-          in: path
-          description: 'key: UserName of Person'
-          required: true
-          schema:
-            type: string
-          x-ms-docs-key-type: Person
-        - name: If-Match
-          in: header
-          description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
-      responses:
-        '204':
-          description: Success
+                type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -2438,7 +2365,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '201':
@@ -2446,36 +2373,7 @@ paths:
           content:
             application/json:
               schema:
-                type: String
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - NewComePeople.Trip
-      summary: Delete ref of navigation property Trips for NewComePeople
-      operationId: NewComePeople.DeleteRefTrips
-      parameters:
-        - name: UserName
-          in: path
-          description: 'key: UserName of Person'
-          required: true
-          schema:
-            type: string
-          x-ms-docs-key-type: Person
-        - name: If-Match
-          in: header
-          description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
-      responses:
-        '204':
-          description: Success
+                type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -3118,7 +3016,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '201':
@@ -3126,36 +3024,7 @@ paths:
           content:
             application/json:
               schema:
-                type: String
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - People.Person
-      summary: Delete ref of navigation property Friends for People
-      operationId: People.DeleteRefFriends
-      parameters:
-        - name: UserName
-          in: path
-          description: 'key: UserName of Person'
-          required: true
-          schema:
-            type: string
-          x-ms-docs-key-type: Person
-        - name: If-Match
-          in: header
-          description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
-      responses:
-        '204':
-          description: Success
+                type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -3606,7 +3475,7 @@ paths:
         content:
           application/json:
             schema:
-              type: String
+              type: object
         required: true
       responses:
         '201':
@@ -3614,36 +3483,7 @@ paths:
           content:
             application/json:
               schema:
-                type: String
-        default:
-          $ref: '#/components/responses/error'
-      x-ms-docs-operation-type: operation
-    delete:
-      tags:
-        - People.Trip
-      summary: Delete ref of navigation property Trips for People
-      operationId: People.DeleteRefTrips
-      parameters:
-        - name: UserName
-          in: path
-          description: 'key: UserName of Person'
-          required: true
-          schema:
-            type: string
-          x-ms-docs-key-type: Person
-        - name: If-Match
-          in: header
-          description: ETag
-          schema:
-            type: string
-        - name: '@id'
-          in: query
-          description: Delete Uri
-          schema:
-            type: string
-      responses:
-        '204':
-          description: Success
+                type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -883,6 +883,8 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -1270,6 +1272,8 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -1925,6 +1929,8 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -2386,6 +2392,8 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -3041,6 +3049,8 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -3502,6 +3512,8 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -610,6 +610,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '204':
@@ -871,6 +873,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '201':
@@ -1256,6 +1260,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '201':
@@ -1610,6 +1616,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '204':
@@ -1907,6 +1915,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '201':
@@ -2366,6 +2376,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '201':
@@ -2720,6 +2732,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '204':
@@ -3017,6 +3031,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '201':
@@ -3476,6 +3492,8 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties:
+                type: object
         required: true
       responses:
         '201':

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Resources/TripService.OpenApi.yaml
@@ -883,8 +883,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties:
-                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -1272,8 +1270,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties:
-                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -1929,8 +1925,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties:
-                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -2392,8 +2386,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties:
-                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -3049,8 +3041,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties:
-                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -3512,8 +3502,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties:
-                  type: object
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/291
Proposes:
- Updating the update operation for `/$ref` paths from `PATCH` to `PUT`. See [documentation](http://docs.oasis-open.org/odata/odata/v4.0/os/part1-protocol/odata-v4.0-os-part1-protocol.html#_Toc372793759).
- Updating the tests appropriately inline with the above changes.
- Updating the `RequestBody` schema from type `string` to `object` since it will be a key-value pair representation. See [documentation](https://docs.microsoft.com/en-us/graph/api/group-post-members?view=graph-rest-1.0&tabs=http#request-1).
