### PR TITLE
Supports generation of stream paths

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Common/Constants.cs
@@ -16,6 +16,11 @@ namespace Microsoft.OpenApi.OData.Common
         public static string ApplicationJsonMediaType = "application/json";
 
         /// <summary>
+        /// application/octet-stream
+        /// </summary>
+        public static string ApplicationOctetStreamMediaType = "application/octet-stream";
+
+        /// <summary>
         /// Status code: 200
         /// </summary>
         public static string StatusCode200 = "200";

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPath.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPath.cs
@@ -258,7 +258,11 @@ namespace Microsoft.OpenApi.OData.Edm
 
         private ODataPathKind CalcPathType()
         {
-            if (Segments.Any(c => c.Kind == ODataSegmentKind.Ref))
+            if (Segments.Any(c => c.Kind == ODataSegmentKind.StreamProperty || c.Kind == ODataSegmentKind.StreamContent))
+            {
+                return ODataPathKind.MediaEntity;
+            }
+            else if (Segments.Any(c => c.Kind == ODataSegmentKind.Ref))
             {
                 return ODataPathKind.Ref;
             }

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathKind.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathKind.cs
@@ -36,14 +36,19 @@ namespace Microsoft.OpenApi.OData.Edm
         OperationImport,
 
         /// <summary>
-        /// Represents an navigation propert path, for example: ~/users/{id}/onedrive
+        /// Represents an navigation property path, for example: ~/users/{id}/onedrive
         /// </summary>
         NavigationProperty,
 
         /// <summary>
-        /// Represents an navigation propert $ref path, for example: ~/users/{id}/onedrive/$ref
+        /// Represents an navigation property $ref path, for example: ~/users/{id}/onedrive/$ref
         /// </summary>
         Ref,
+
+        /// <summary>
+        /// Represents a media entity path, for example: ~/me/photo/$value or ~/reports/deviceConfigurationUserActivity/Content
+        /// </summary>
+        MediaEntity,
 
         /// <summary>
         /// Represents an un-supported/unknown path.

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataSegment.cs
@@ -47,7 +47,17 @@ namespace Microsoft.OpenApi.OData.Edm
         /// <summary>
         /// $ref
         /// </summary>
-        Ref
+        Ref,
+
+        /// <summary>
+        /// Stream content -> $value
+        /// </summary>
+        StreamContent,
+
+        /// <summary>
+        /// Stream property
+        /// </summary>
+        StreamProperty
     }
 
     /// <summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamContentSegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamContentSegment.cs
@@ -1,0 +1,24 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace Microsoft.OpenApi.OData.Edm
+{
+    /// <summary>
+    /// Stream segment.
+    /// </summary>
+    public class ODataStreamContentSegment : ODataSegment
+    {
+        /// <inheritdoc />
+        public override ODataSegmentKind Kind => ODataSegmentKind.StreamContent;
+
+        /// <inheritdoc />
+        public override string Identifier => "$value";
+
+        /// <inheritdoc />
+        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => "$value";
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamPropertySegment.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataStreamPropertySegment.cs
@@ -1,0 +1,34 @@
+﻿//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.OpenApi.OData.Common;
+
+namespace Microsoft.OpenApi.OData.Edm
+{
+    /// <summary>
+    /// Property Stream segment.
+    /// </summary>
+    public class ODataStreamPropertySegment : ODataSegment
+    {
+        private readonly string _streamPropertyName;
+        /// <summary>
+        /// Initializes a new instance of <see cref="ODataTypeCastSegment"/> class.
+        /// </summary>
+        /// <param name="streamPropertyName">The name of the stream property.</param>
+        public ODataStreamPropertySegment(string streamPropertyName)
+        {
+            _streamPropertyName = streamPropertyName ?? throw Error.ArgumentNull(nameof(streamPropertyName));
+        }
+
+        /// <inheritdoc />
+        public override ODataSegmentKind Kind => ODataSegmentKind.StreamProperty;
+
+        /// <inheritdoc />
+        public override string Identifier { get => _streamPropertyName; }
+
+        /// <inheritdoc />
+        public override string GetPathItemName(OpenApiConvertSettings settings, HashSet<string> parameters) => _streamPropertyName;
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -1,0 +1,109 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.OpenApi.OData.Operation
+{
+    /// <summary>
+    /// Retrieve a media content for an Entity
+    /// </summary>
+    internal class MediaEntityGetOperationHandler : EntitySetOperationHandler
+    {
+        /// <inheritdoc/>
+        public override OperationType OperationType => OperationType.Get;
+
+        /// <inheritdoc/>
+        protected override void SetBasicInfo(OpenApiOperation operation)
+        {
+            string typeName = EntitySet.EntityType().Name;
+
+            // Summary
+            operation.Summary = $"Get media content for {typeName} from {EntitySet.Name}";
+
+            // OperationId
+            if (Context.Settings.EnableOperationId)
+            {
+                string identifier = Path.LastSegment.Kind == ODataSegmentKind.StreamContent ? "Content" : Path.LastSegment.Identifier;
+                operation.OperationId = EntitySet.Name + "." + typeName + ".Get" + Utils.UpperFirstChar(identifier);
+            }
+
+            base.SetBasicInfo(operation);
+        }
+
+        /// <inheritdoc/>
+        protected override void SetResponses(OpenApiOperation operation)
+        {
+            OpenApiSchema schema = null;
+
+            if (Context.Settings.EnableDerivedTypesReferencesForResponses)
+            {
+                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
+            }
+
+            if (schema == null)
+            {
+                schema = new OpenApiSchema
+                {
+                    Type = "string",
+                    Format = "binary"
+                };
+            }
+
+            operation.Responses = new OpenApiResponses
+            {
+                {
+                    Constants.StatusCode200,
+                    new OpenApiResponse
+                    {
+                        Description = "Retrieved media content",
+                        Content = new Dictionary<string, OpenApiMediaType>
+                        {
+                            {
+                                Constants.ApplicationOctetStreamMediaType,
+                                new OpenApiMediaType
+                                {
+                                    Schema = schema
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+            operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
+
+            base.SetResponses(operation);
+        }
+        /// <inheritdoc/>
+        protected override void SetSecurity(OpenApiOperation operation)
+        {
+            ReadRestrictionsType read = Context.Model.GetRecord<ReadRestrictionsType>(EntitySet, CapabilitiesConstants.ReadRestrictions);
+            if (read == null)
+            {
+                return;
+            }
+
+            ReadRestrictionsBase readBase = read;
+            if (read.ReadByKeyRestrictions != null)
+            {
+                readBase = read.ReadByKeyRestrictions;
+            }
+
+            if (readBase == null && readBase.Permissions == null)
+            {
+                return;
+            }
+
+            operation.Security = Context.CreateSecurityRequirements(readBase.Permissions).ToList();
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -1,0 +1,104 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Generator;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+
+namespace Microsoft.OpenApi.OData.Operation
+{
+    /// <summary>
+    /// Update a media content for an Entity
+    /// </summary>
+    internal class MediaEntityPutOperationHandler : EntitySetOperationHandler
+    {
+        /// <inheritdoc/>
+        public override OperationType OperationType => OperationType.Put;
+
+        /// <inheritdoc/>
+        protected override void SetBasicInfo(OpenApiOperation operation)
+        {
+            string typeName = EntitySet.EntityType().Name;
+
+            // Summary
+            operation.Summary = $"Update media content for {typeName} in {EntitySet.Name}";
+
+            // OperationId
+            if (Context.Settings.EnableOperationId)
+            {
+                string identifier = Path.LastSegment.Kind == ODataSegmentKind.StreamContent ? "Content" : Path.LastSegment.Identifier;
+                operation.OperationId = EntitySet.Name + "." + typeName + ".Update" + Utils.UpperFirstChar(identifier);
+            }
+
+            base.SetBasicInfo(operation);
+        }
+
+        /// <inheritdoc/>
+        protected override void SetRequestBody(OpenApiOperation operation)
+        {
+            OpenApiSchema schema = null;
+
+            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
+            {
+                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
+            }
+
+            if (schema == null)
+            {
+                schema = new OpenApiSchema
+                {
+                    Type = "string",
+                    Format = "binary"
+                };
+            }
+
+            operation.RequestBody = new OpenApiRequestBody
+            {
+                Required = true,
+                Description = "New media content.",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    {
+                        Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
+                        {
+                            Schema = schema
+                        }
+                    }
+                }
+            };
+
+            base.SetRequestBody(operation);
+        }
+
+        /// <inheritdoc/>
+        protected override void SetResponses(OpenApiOperation operation)
+        {
+            operation.Responses = new OpenApiResponses
+            {
+                { Constants.StatusCode204, Constants.StatusCode204.GetResponse() },
+                { Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse() }
+            };
+
+            base.SetResponses(operation);
+        }
+
+        /// <inheritdoc/>
+        protected override void SetSecurity(OpenApiOperation operation)
+        {
+            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
+            if (update == null || update.Permissions == null)
+            {
+                return;
+            }
+
+            operation.Security = Context.CreateSecurityRequirements(update.Permissions).ToList();
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/OperationHandlerProvider.cs
@@ -76,6 +76,13 @@ namespace Microsoft.OpenApi.OData.Operation
                 {OperationType.Post, new RefPostOperationHandler() },
                 {OperationType.Delete, new RefDeleteOperationHandler() }
             };
+
+            // media entity operation (Get|Put)
+            _handlers[ODataPathKind.MediaEntity] = new Dictionary<OperationType, IOperationHandler>
+            {
+                {OperationType.Get, new MediaEntityGetOperationHandler() },
+                {OperationType.Put, new MediaEntityPutOperationHandler() }
+            };
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/MediaEntityPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/MediaEntityPathItemHandler.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
+
+namespace Microsoft.OpenApi.OData.PathItem
+{
+    /// <summary>
+    /// Create a <see cref="OpenApiPathItem"/> for a media entity.
+    /// </summary>
+    internal class MediaEntityPathItemHandler : EntitySetPathItemHandler
+    {
+        /// <inheritdoc/>
+        protected override ODataPathKind HandleKind => ODataPathKind.MediaEntity;
+
+        /// <inheritdoc/>
+        protected override void SetOperations(OpenApiPathItem item)
+        {
+            ReadRestrictionsType read = Context.Model.GetRecord<ReadRestrictionsType>(EntitySet);
+            if (read == null ||
+               (read.ReadByKeyRestrictions == null && read.IsReadable) ||
+               (read.ReadByKeyRestrictions != null && read.ReadByKeyRestrictions.IsReadable))
+            {
+                AddOperation(item, OperationType.Get);
+            }
+
+            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet);
+            if (update == null || update.IsUpdatable)
+            {
+                AddOperation(item, OperationType.Put);
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandlerProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/PathItemHandlerProvider.cs
@@ -36,6 +36,9 @@ namespace Microsoft.OpenApi.OData.PathItem
             // Edm Ref
             { ODataPathKind.Ref, new RefPathItemHandler() },
 
+            // Media Entity
+            {ODataPathKind.MediaEntity, new MediaEntityPathItemHandler() },
+
             // Unknown
             { ODataPathKind.Unknown, null },
         };

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         }
 
         [Fact]
-        public void KindPropertyReturnsUnknow()
+        public void KindPropertyReturnsUnknown()
         {
             // Arrange
             ODataKeySegment keySegment = new ODataKeySegment(_simpleKeyEntityType);
@@ -196,6 +196,32 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Act & Assert
             Assert.Equal(ODataPathKind.OperationImport, path.Kind);
+        }
+
+        [Fact]
+        public void KindPropertyReturnsStreamProperty()
+        {
+            // Arrange
+            ODataNavigationSourceSegment nsSegment = new ODataNavigationSourceSegment(_simpleKeyEntitySet);
+            ODataKeySegment keySegment = new ODataKeySegment(_simpleKeyEntityType);
+            ODataStreamPropertySegment streamPropSegment = new ODataStreamPropertySegment("Logo");
+            ODataPath path = new ODataPath(nsSegment, keySegment, streamPropSegment);
+
+            // Act & Assert
+            Assert.Equal(ODataPathKind.MediaEntity, path.Kind);
+        }
+
+        [Fact]
+        public void KindPropertyReturnsStreamContent()
+        {
+            // Arrange
+            ODataNavigationSourceSegment nsSegment = new ODataNavigationSourceSegment(_simpleKeyEntitySet);
+            ODataKeySegment keySegment = new ODataKeySegment(_simpleKeyEntityType);
+            ODataStreamContentSegment streamContSegment = new ODataStreamContentSegment();
+            ODataPath path = new ODataPath(nsSegment, keySegment, streamContSegment);
+
+            // Act & Assert
+            Assert.Equal(ODataPathKind.MediaEntity, path.Kind);
         }
 
         [Theory]

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataStreamContentSegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataStreamContentSegmentTests.cs
@@ -1,0 +1,57 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Edm.Tests
+{
+    public class ODataStreamContentSegmentTests
+    {
+        private readonly EdmEntityType _todo;
+
+        public ODataStreamContentSegmentTests()
+        {
+            _todo = new EdmEntityType("microsoft.graph", "Todo",
+                new EdmEntityType("microsoft.graph", "Task"),
+                isAbstract: false,
+                isOpen: false,
+                hasStream: true);
+            _todo.AddKeys(_todo.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String));
+            _todo.AddKeys(_todo.AddStructuralProperty("Logo", EdmPrimitiveTypeKind.Stream));
+            _todo.AddKeys(_todo.AddStructuralProperty("Description", EdmPrimitiveTypeKind.String));
+        }
+
+        [Fact]
+        public void StreamContentSegmentIdentifierPropertyReturnsCorrectDefaultValue()
+        {
+            // Arrange & Act
+            ODataStreamContentSegment segment = new ODataStreamContentSegment();
+
+            // Assert
+            Assert.Same("$value", segment.Identifier);
+        }
+
+        [Fact]
+        public void KindPropertyReturnsStreamContentEnumMember()
+        {
+            // Arrange & Act
+            ODataStreamContentSegment segment = new ODataStreamContentSegment();
+
+            // Assert
+            Assert.Equal(ODataSegmentKind.StreamContent, segment.Kind);
+        }
+
+        [Fact]
+        public void GetPathItemNameReturnsCorrectDefaultStreamContentValue()
+        {
+            // Arrange & Act
+            ODataStreamContentSegment segment = new ODataStreamContentSegment();
+
+            // Assert
+            Assert.Equal("$value", segment.GetPathItemName(new OpenApiConvertSettings()));
+        }
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataStreamPropertySegmentTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataStreamPropertySegmentTests.cs
@@ -1,0 +1,70 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Edm.Tests
+{
+    public class ODataStreamPropertySegmentTests
+    {
+        private readonly EdmEntityType _todo;
+
+        public ODataStreamPropertySegmentTests()
+        {
+            _todo = new EdmEntityType("microsoft.graph", "Todo");
+            _todo.AddKeys(_todo.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String));
+            _todo.AddKeys(_todo.AddStructuralProperty("Logo", EdmPrimitiveTypeKind.Stream));
+            _todo.AddKeys(_todo.AddStructuralProperty("Description", EdmPrimitiveTypeKind.String));
+        }
+
+        [Fact]
+        public void StreamPropertySegmentConstructorThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>("streamPropertyName", () => new ODataStreamPropertySegment(null));
+        }
+
+        [Fact]
+        public void StreamPropertySegmentIdentifierPropertyReturnsStreamPropertyNameOfEntity()
+        {
+            // Arrange
+            var streamPropName = _todo.DeclaredStructuralProperties().First(c => c.Name == "Logo").Name;
+
+            // Act
+            ODataStreamPropertySegment segment = new ODataStreamPropertySegment(streamPropName);
+
+            // Assert
+            Assert.Same(streamPropName, segment.Identifier);
+        }
+
+        [Fact]
+        public void KindPropertyReturnsStreamPropertyEnumMember()
+        {
+            // Arrange
+            var streamPropName = _todo.DeclaredStructuralProperties().First(c => c.Name == "Logo").Name;
+
+            // Act
+            ODataStreamPropertySegment segment = new ODataStreamPropertySegment(streamPropName);
+
+            // Assert
+            Assert.Equal(ODataSegmentKind.StreamProperty, segment.Kind);
+        }
+
+        [Fact]
+        public void GetPathItemNameReturnsCorrectStreamPropertyNameOfEntity()
+        {
+            // Arrange
+            var streamPropName = _todo.DeclaredStructuralProperties().First(c => c.Name == "Logo").Name;
+
+            // Act
+            ODataStreamPropertySegment segment = new ODataStreamPropertySegment(streamPropName);
+
+            // Assert
+            Assert.Equal(streamPropName, segment.GetPathItemName(new OpenApiConvertSettings()));
+        }
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -1,0 +1,89 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OpenApi.OData.Edm;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Operation.Tests
+{
+    public class MediaEntityGetOperationHandlerTests
+    {
+        private readonly MediaEntityGetOperationHandler _operationalHandler = new MediaEntityGetOperationHandler();
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CreateMediaEntityGetOperationReturnsCorrectOperation(bool enableOperationId)
+        {
+            // Arrange
+            IEdmModel model = GetEdmModel();
+            OpenApiConvertSettings settings = new OpenApiConvertSettings
+            {
+                EnableOperationId = enableOperationId
+            };
+
+            ODataContext context = new ODataContext(model, settings);
+            IEdmEntitySet todos = model.EntityContainer.FindEntitySet("Todos");
+            Assert.NotNull(todos);
+
+            IEdmEntityType todo = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Todo");
+            IEdmStructuralProperty sp = todo.DeclaredStructuralProperties().First(c => c.Name == "Logo");
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(todos),
+                new ODataKeySegment(todos.EntityType()),
+                new ODataStreamPropertySegment(sp.Name));
+
+            // Act
+            var getOperation = _operationalHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(getOperation);
+            Assert.Equal("Get media content for Todo from Todos", getOperation.Summary);
+            Assert.NotNull(getOperation.Tags);
+            var tag = Assert.Single(getOperation.Tags);
+            Assert.Equal("Todos.Todo", tag.Name);
+
+            Assert.NotNull(getOperation.Responses);
+            Assert.Equal(2, getOperation.Responses.Count);
+            Assert.Equal(new[] { "200", "default" }, getOperation.Responses.Select(r => r.Key));
+
+            if (enableOperationId)
+            {
+                Assert.Equal("Todos.Todo.GetLogo", getOperation.OperationId);
+            }
+            else
+            {
+                Assert.Null(getOperation.OperationId);
+            }
+        }
+
+        public static IEdmModel GetEdmModel()
+        {
+            const string modelText = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""microsoft.graph"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Todo"" HasStream=""true"">
+        <Key>
+          <PropertyRef Name=""Id"" />
+        </Key>
+        <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Logo"" Type=""Edm.Stream""/>
+        <Property Name = ""Description"" Type = ""Edm.String"" />
+         </EntityType>
+      <EntityContainer Name =""TodoService"">
+         <EntitySet Name=""Todos"" EntityType=""microsoft.graph.Todo"" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+            bool result = CsdlReader.TryParse(XElement.Parse(modelText).CreateReader(), out IEdmModel model, out _);
+            Assert.True(result);
+            return model;
+        }
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
@@ -1,0 +1,63 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.OData.Edm;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.Operation.Tests
+{
+    public class MediaEntityPutOperationHandlerTests
+    {
+        private readonly MediaEntityPutOperationHandler _operationalHandler = new MediaEntityPutOperationHandler();
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CreateEntityPutOperationReturnsCorrectOperation(bool enableOperationId)
+        {
+            // Arrange
+            IEdmModel model = MediaEntityGetOperationHandlerTests.GetEdmModel();
+            OpenApiConvertSettings settings = new OpenApiConvertSettings
+            {
+                EnableOperationId = enableOperationId
+            };
+
+            ODataContext context = new ODataContext(model, settings);
+            IEdmEntitySet todos = model.EntityContainer.FindEntitySet("Todos");
+            Assert.NotNull(todos);
+
+            IEdmEntityType todo = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Todo");
+            IEdmStructuralProperty sp = todo.DeclaredStructuralProperties().First(c => c.Name == "Logo");
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(todos),
+                new ODataKeySegment(todos.EntityType()),
+                new ODataStreamPropertySegment(sp.Name));
+
+            // Act
+            var getOperation = _operationalHandler.CreateOperation(context, path);
+
+            // Assert
+            Assert.NotNull(getOperation);
+            Assert.Equal("Update media content for Todo in Todos", getOperation.Summary);
+            Assert.NotNull(getOperation.Tags);
+            var tag = Assert.Single(getOperation.Tags);
+            Assert.Equal("Todos.Todo", tag.Name);
+
+            Assert.NotNull(getOperation.Responses);
+            Assert.Equal(2, getOperation.Responses.Count);
+            Assert.Equal(new[] { "204", "default" }, getOperation.Responses.Select(r => r.Key));
+
+            if (enableOperationId)
+            {
+                Assert.Equal("Todos.Todo.UpdateLogo", getOperation.OperationId);
+            }
+            else
+            {
+                Assert.Null(getOperation.OperationId);
+            }
+        }
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/OperationHandlerProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/OperationHandlerProviderTests.cs
@@ -32,6 +32,8 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         [InlineData(ODataPathKind.Ref, OperationType.Delete, typeof(RefDeleteOperationHandler))]
         [InlineData(ODataPathKind.Ref, OperationType.Get, typeof(RefGetOperationHandler))]
         [InlineData(ODataPathKind.Ref, OperationType.Put, typeof(RefPutOperationHandler))]
+        [InlineData(ODataPathKind.MediaEntity, OperationType.Get, typeof(MediaEntityGetOperationHandler))]
+        [InlineData(ODataPathKind.MediaEntity, OperationType.Put, typeof(MediaEntityPutOperationHandler))]
         public void GetHandlerReturnsCorrectOperationHandlerType(ODataPathKind pathKind, OperationType operationType, Type handlerType)
         {
             // Arrange

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/MediaEntityPathItemHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/MediaEntityPathItemHandlerTests.cs
@@ -1,0 +1,206 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Edm;
+using Microsoft.OpenApi.OData.Properties;
+using System;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Microsoft.OpenApi.OData.PathItem.Tests
+{
+    public class MediaEntityPathItemHandlerTests
+    {
+        private readonly MediaEntityPathItemHandler _pathItemHandler = new MyMediaEntityPathItemHandler();
+
+        [Fact]
+        public void CreatePathItemThrowsForNullContext()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>("context",
+                () => _pathItemHandler.CreatePathItem(context: null, path: new ODataPath()));
+        }
+
+        [Fact]
+        public void CreatePathItemThrowsForNullPath()
+        {
+            // Arrange & Act & Assert
+            Assert.Throws<ArgumentNullException>("path",
+                () => _pathItemHandler.CreatePathItem(new ODataContext(EdmCoreModel.Instance), path: null));
+        }
+
+        [Fact]
+        public void CreatePathItemThrowsForNonMediaEntityPath()
+        {
+            // Arrange
+            IEdmModel model = GetEdmModel("");
+            ODataContext context = new ODataContext(model);
+            var entitySet = model.EntityContainer.FindEntitySet("Todos");
+            Assert.NotNull(entitySet); // guard
+            var path = new ODataPath(new ODataNavigationSourceSegment(entitySet));
+
+            // Act
+            void test() => _pathItemHandler.CreatePathItem(context, path);
+
+            // Assert
+            var exception = Assert.Throws<InvalidOperationException>(test);
+            Assert.Equal(string.Format(SRResource.InvalidPathKindForPathItemHandler, _pathItemHandler.GetType().Name, path.Kind), exception.Message);
+        }
+
+        [Fact]
+        public void CreateMediaEntityPathItemReturnsCorrectItem()
+        {
+            // Arrange
+            IEdmModel model = GetEdmModel("");
+            ODataContext context = new ODataContext(model);
+            var entitySet = model.EntityContainer.FindEntitySet("Todos");
+            Assert.NotNull(entitySet); // guard
+            IEdmEntityType entityType = entitySet.EntityType();
+
+            IEdmStructuralProperty sp = entityType.DeclaredStructuralProperties().First(c => c.Name == "Logo");
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(entitySet),
+                new ODataKeySegment(entityType),
+                new ODataStreamPropertySegment(sp.Name));
+
+            // Act
+            var pathItem = _pathItemHandler.CreatePathItem(context, path);
+
+            Assert.NotNull(pathItem.Operations);
+            Assert.NotEmpty(pathItem.Operations);
+            Assert.Equal(2, pathItem.Operations.Count);
+            Assert.Equal(new OperationType[] { OperationType.Get, OperationType.Put },
+                pathItem.Operations.Select(o => o.Key));
+        }
+
+        [Theory]
+        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Put })]
+        [InlineData(false, new OperationType[] { OperationType.Put })]
+        public void CreateMediaEntityPathItemWorksForReadByKeyRestrictionsCapablities(bool readable, OperationType[] expected)
+        {
+            // Arrange
+            string annotation = $@"
+<Annotation Term=""Org.OData.Capabilities.V1.ReadRestrictions"">
+  <Record>
+    <PropertyValue Property=""ReadByKeyRestrictions"" >
+      <Record>
+        <PropertyValue Property=""Readable"" Bool=""{readable}"" />
+      </Record>
+    </PropertyValue>
+  </Record>
+</Annotation>";
+
+            // Assert
+            VerifyPathItemOperationsForStreamPropertySegment(annotation, expected);
+            VerifyPathItemOperationsForStreamContentSegment(annotation, expected);
+        }
+
+        [Theory]
+        [InlineData(true, new OperationType[] { OperationType.Get, OperationType.Put })]
+        [InlineData(false, new OperationType[] { OperationType.Get })]
+        public void CreateMediaEntityPathItemWorksForUpdateRestrictionsCapablities(bool updatable, OperationType[] expected)
+        {
+            // Arrange
+            string annotation = $@"
+<Annotation Term=""Org.OData.Capabilities.V1.UpdateRestrictions"">
+  <Record>
+    <PropertyValue Property=""Updatable"" Bool=""{updatable}"" />
+  </Record>
+</Annotation>";
+
+            // Assert
+            VerifyPathItemOperationsForStreamPropertySegment(annotation, expected);
+            VerifyPathItemOperationsForStreamContentSegment(annotation, expected);
+        }
+
+        private void VerifyPathItemOperationsForStreamPropertySegment(string annotation, OperationType[] expected)
+        {
+            // Arrange
+            IEdmModel model = GetEdmModel(annotation);
+            ODataContext context = new ODataContext(model);
+            IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("Todos");
+            Assert.NotNull(entitySet); // guard
+            IEdmEntityType entityType = entitySet.EntityType();
+
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(entitySet),
+                new ODataKeySegment(entityType),
+                new ODataStreamContentSegment());
+
+            // Act
+            var pathItem = _pathItemHandler.CreatePathItem(context, path);
+
+            // Assert
+            Assert.NotNull(pathItem);
+
+            Assert.NotNull(pathItem.Operations);
+            Assert.NotEmpty(pathItem.Operations);
+            Assert.Equal(expected, pathItem.Operations.Select(e => e.Key));
+        }
+
+        private void VerifyPathItemOperationsForStreamContentSegment(string annotation, OperationType[] expected)
+        {
+            // Arrange
+            IEdmModel model = GetEdmModel(annotation);
+            ODataContext context = new ODataContext(model);
+            IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("Todos");
+            Assert.NotNull(entitySet); // guard
+            IEdmEntityType entityType = entitySet.EntityType();
+
+            IEdmStructuralProperty sp = entityType.DeclaredStructuralProperties().First(c => c.Name == "Logo");
+            ODataPath path = new ODataPath(new ODataNavigationSourceSegment(entitySet),
+                new ODataKeySegment(entityType),
+                new ODataStreamPropertySegment(sp.Name));
+
+            // Act
+            var pathItem = _pathItemHandler.CreatePathItem(context, path);
+
+            // Assert
+            Assert.NotNull(pathItem);
+
+            Assert.NotNull(pathItem.Operations);
+            Assert.NotEmpty(pathItem.Operations);
+            Assert.Equal(expected, pathItem.Operations.Select(e => e.Key));
+        }
+
+        private IEdmModel GetEdmModel(string annotation)
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""microsoft.graph"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Todo"" HasStream=""true"">
+        <Key>
+          <PropertyRef Name=""Id"" />
+        </Key>
+        <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Logo"" Type=""Edm.Stream""/>
+        <Property Name = ""Description"" Type = ""Edm.String"" />
+         </EntityType>
+      <EntityContainer Name =""TodoService"">
+         <EntitySet Name=""Todos"" EntityType=""microsoft.graph.Todo"" />
+      </EntityContainer>
+      <Annotations Target=""microsoft.graph.TodoService/Todos"">
+        {0}
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+            string modelText = string.Format(template, annotation);
+            bool result = CsdlReader.TryParse(XElement.Parse(modelText).CreateReader(), out IEdmModel model, out _);
+            Assert.True(result);
+            return model;
+        }
+    }
+
+    internal class MyMediaEntityPathItemHandler : MediaEntityPathItemHandler
+    {
+        protected override void AddOperation(OpenApiPathItem item, OperationType operationType)
+        {
+            item.AddOperation(operationType, new OpenApiOperation());
+        }
+    }
+}

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/PathItemHandlerProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/PathItem/PathItemHandlerProviderTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.OpenApi.OData.PathItem.Tests
         [InlineData(ODataPathKind.Operation, typeof(OperationPathItemHandler))]
         [InlineData(ODataPathKind.OperationImport, typeof(OperationImportPathItemHandler))]
         [InlineData(ODataPathKind.Ref, typeof(RefPathItemHandler))]
+        [InlineData(ODataPathKind.MediaEntity, typeof(MediaEntityPathItemHandler))]
         public void GetHandlerReturnsCorrectHandlerType(ODataPathKind pathKind, Type handlerType)
         {
             // Arrange


### PR DESCRIPTION
Closes https://github.com/microsoft/OpenAPI.NET.OData/issues/71

Proposes: 
- Adds functionality for generating stream paths for entities with property `HasStream = true` and/or with properties of type `Edm.Stream`
- Adds and/or updates tests to validate the above functionality.