### PR TITLE
Adds support for creating a media entity

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -184,31 +184,7 @@ namespace Microsoft.OpenApi.OData.Edm
             }
 
             // media entity
-            bool createValuePath = true;
-            foreach (IEdmStructuralProperty sp in entityType.DeclaredStructuralProperties())
-            {
-                if (sp.Type.AsPrimitive().IsStream())
-                {
-                    path.Push(new ODataStreamPropertySegment(sp.Name));
-                    AppendPath(path.Clone());
-                    path.Pop();
-                }
-
-                if (sp.Name.Equals("content", System.StringComparison.OrdinalIgnoreCase))
-                {
-                    createValuePath = false;
-                }
-            }
-
-            /* Create a /$value path only if entity has stream and
-             * does not contain a structural property named Content
-             */
-            if (createValuePath && entityType.HasStream)
-            {
-                path.Push(new ODataStreamContentSegment());
-                AppendPath(path.Clone());
-                path.Pop();
-            }
+            RetrieveMediaEntityStreamPaths(entityType, path);
 
             // navigation property
             foreach (IEdmNavigationProperty np in entityType.DeclaredNavigationProperties())
@@ -226,6 +202,43 @@ namespace Microsoft.OpenApi.OData.Edm
 
             path.Pop(); // end of navigation source.
             Debug.Assert(path.Any() == false);
+        }
+
+        /// <summary>
+        /// Retrieves the paths for a media entity stream.
+        /// </summary>
+        /// <param name="entityType">The entity type.</param>
+        /// <param name="currentPath">The current OData path.</param>
+        private void RetrieveMediaEntityStreamPaths(IEdmEntityType entityType, ODataPath currentPath)
+        {
+            Debug.Assert(entityType != null);
+            Debug.Assert(currentPath != null);
+
+            bool createValuePath = true;
+            foreach (IEdmStructuralProperty sp in entityType.DeclaredStructuralProperties())
+            {
+                if (sp.Type.AsPrimitive().IsStream())
+                {
+                    currentPath.Push(new ODataStreamPropertySegment(sp.Name));
+                    AppendPath(currentPath.Clone());
+                    currentPath.Pop();
+                }
+
+                if (sp.Name.Equals("content", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    createValuePath = false;
+                }
+            }
+
+            /* Create a /$value path only if entity has stream and
+             * does not contain a structural property named Content
+             */
+            if (createValuePath && entityType.HasStream)
+            {
+                currentPath.Push(new ODataStreamContentSegment());
+                AppendPath(currentPath.Clone());
+                currentPath.Pop();
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Edm/ODataPathProvider.cs
@@ -284,6 +284,10 @@ namespace Microsoft.OpenApi.OData.Edm
                         }
                     }
                 }
+
+                // Get possible navigation property stream paths
+                RetrieveMediaEntityStreamPaths(navEntityType, currentPath);
+
                 if (navigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
                 {
                     currentPath.Pop();

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
@@ -70,7 +70,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 content = new Dictionary<string, OpenApiMediaType>
                 {
                     {
-                        // TODO: Read the AcceptableMediaType annotation from CSDL
+                        // TODO: Read the AcceptableMediaType annotation from model
                         Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
                         {
                             Schema = schema
@@ -133,7 +133,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 content = new Dictionary<string, OpenApiMediaType>
                 {
                     {
-                        // TODO: Read the AcceptableMediaType annotation from CSDL
+                        // TODO: Read the AcceptableMediaType annotation from model
                         Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
                         {
                             Schema = schema

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
@@ -43,61 +43,13 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetRequestBody(OpenApiOperation operation)
         {
-            OpenApiSchema schema = null;
-
-            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
-            {
-                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
-            }
-
-            if (schema == null)
-            {
-                schema = new OpenApiSchema
-                {
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.Schema,
-                        Id = EntitySet.EntityType().FullName()
-                    }
-                };
-            }
-
-            IDictionary<string, OpenApiMediaType> content;
-
-            if (EntitySet.EntityType().HasStream)
-            {
-                // Support creating a media entity
-                content = new Dictionary<string, OpenApiMediaType>
-                {
-                    {
-                        // TODO: Read the AcceptableMediaType annotation from model
-                        Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
-                        {
-                            Schema = schema
-                        }
-                    }
-                };
-            }
-            else
-            {
-                content = new Dictionary<string, OpenApiMediaType>
-                {
-                    {
-                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
-                        {
-                            Schema = schema
-                        }
-                    }
-                };
-            }
-
             // The requestBody field contains a Request Body Object for the request body
             // that references the schema of the entity set’s entity type in the global schemas.
             operation.RequestBody = new OpenApiRequestBody
             {
                 Required = true,
                 Description = "New entity",
-                Content = content
+                Content = GetContentDescription()
             };
 
             base.SetRequestBody(operation);
@@ -106,54 +58,6 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetResponses(OpenApiOperation operation)
         {
-            OpenApiSchema schema = null;
-
-            if (Context.Settings.EnableDerivedTypesReferencesForResponses)
-            {
-                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
-            }
-
-            if (schema == null)
-            {
-                schema = new OpenApiSchema
-                {
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.Schema,
-                        Id = EntitySet.EntityType().FullName()
-                    }
-                };
-            }
-
-            IDictionary<string, OpenApiMediaType> content;
-
-            if (EntitySet.EntityType().HasStream)
-            {
-                // Support creating a media entity
-                content = new Dictionary<string, OpenApiMediaType>
-                {
-                    {
-                        // TODO: Read the AcceptableMediaType annotation from model
-                        Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
-                        {
-                            Schema = schema
-                        }
-                    }
-                };
-            }
-            else
-            {
-                content = new Dictionary<string, OpenApiMediaType>
-                {
-                    {
-                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
-                        {
-                            Schema = schema
-                        }
-                    }
-                };
-            }
-
             operation.Responses = new OpenApiResponses
             {
                 {
@@ -161,7 +65,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     new OpenApiResponse
                     {
                         Description = "Created entity",
-                        Content = content
+                        Content = GetContentDescription()
                     }
                 }
             };
@@ -199,6 +103,70 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 AppendCustomParameters(operation, insert.CustomHeaders, ParameterLocation.Header);
             }
+        }
+
+        /// <summary>
+        /// Get the entity content description.
+        /// </summary>
+        /// <returns>The entity content description.</returns>
+        private IDictionary<string, OpenApiMediaType> GetContentDescription()
+        {
+            OpenApiSchema schema = GetEntitySchema();
+
+            if (EntitySet.EntityType().HasStream)
+            {
+                // Support creating a media entity
+                return new Dictionary<string, OpenApiMediaType>
+                {
+                    {
+                        // TODO: Read the AcceptableMediaType annotation from model
+                        Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
+                        {
+                            Schema = schema
+                        }
+                    }
+                };
+            }
+            else
+            {
+                return new Dictionary<string, OpenApiMediaType>
+                {
+                    {
+                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
+                        {
+                            Schema = schema
+                        }
+                    }
+                };
+            }
+        }
+
+        /// <summary>
+        /// Get the entity schema.
+        /// </summary>
+        /// <returns>The entity schema.</returns>
+        private OpenApiSchema GetEntitySchema()
+        {
+            OpenApiSchema schema = null;
+
+            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
+            {
+                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
+            }
+
+            if (schema == null)
+            {
+                schema = new OpenApiSchema
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = EntitySet.EntityType().FullName()
+                    }
+                };
+            }
+
+            return schema;
         }
     }
 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
@@ -122,6 +122,16 @@ namespace Microsoft.OpenApi.OData.Operation
                         // TODO: Read the AcceptableMediaType annotation from model
                         Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
                         {
+                            Schema = new OpenApiSchema
+                            {
+                                Type = "string",
+                                Format = "binary"
+                            }
+                        }
+                    },
+                    {                        
+                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
+                        {
                             Schema = schema
                         }
                     }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
@@ -112,43 +112,27 @@ namespace Microsoft.OpenApi.OData.Operation
         private IDictionary<string, OpenApiMediaType> GetContentDescription()
         {
             OpenApiSchema schema = GetEntitySchema();
+            var content = new Dictionary<string, OpenApiMediaType>();
 
             if (EntitySet.EntityType().HasStream)
             {
-                // Support creating a media entity
-                return new Dictionary<string, OpenApiMediaType>
+                // TODO: Read the AcceptableMediaType annotation from model
+                content.Add(Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
                 {
+                    Schema = new OpenApiSchema
                     {
-                        // TODO: Read the AcceptableMediaType annotation from model
-                        Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
-                        {
-                            Schema = new OpenApiSchema
-                            {
-                                Type = "string",
-                                Format = "binary"
-                            }
-                        }
-                    },
-                    {                        
-                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
-                        {
-                            Schema = schema
-                        }
+                        Type = "string",
+                        Format = "binary"
                     }
-                };
+                });                
             }
-            else
+
+            content.Add(Constants.ApplicationJsonMediaType, new OpenApiMediaType
             {
-                return new Dictionary<string, OpenApiMediaType>
-                {
-                    {
-                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
-                        {
-                            Schema = schema
-                        }
-                    }
-                };
-            }
+                Schema = schema
+            });
+
+            return content;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/EntitySetPostOperationHandler.cs
@@ -62,13 +62,25 @@ namespace Microsoft.OpenApi.OData.Operation
                 };
             }
 
-            // The requestBody field contains a Request Body Object for the request body
-            // that references the schema of the entity set’s entity type in the global schemas.
-            operation.RequestBody = new OpenApiRequestBody
+            IDictionary<string, OpenApiMediaType> content;
+
+            if (EntitySet.EntityType().HasStream)
             {
-                Required = true,
-                Description = "New entity",
-                Content = new Dictionary<string, OpenApiMediaType>
+                // Support creating a media entity
+                content = new Dictionary<string, OpenApiMediaType>
+                {
+                    {
+                        // TODO: Read the AcceptableMediaType annotation from CSDL
+                        Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
+                        {
+                            Schema = schema
+                        }
+                    }
+                };
+            }
+            else
+            {
+                content = new Dictionary<string, OpenApiMediaType>
                 {
                     {
                         Constants.ApplicationJsonMediaType, new OpenApiMediaType
@@ -76,7 +88,16 @@ namespace Microsoft.OpenApi.OData.Operation
                             Schema = schema
                         }
                     }
-                }
+                };
+            }
+
+            // The requestBody field contains a Request Body Object for the request body
+            // that references the schema of the entity set’s entity type in the global schemas.
+            operation.RequestBody = new OpenApiRequestBody
+            {
+                Required = true,
+                Description = "New entity",
+                Content = content
             };
 
             base.SetRequestBody(operation);
@@ -104,6 +125,35 @@ namespace Microsoft.OpenApi.OData.Operation
                 };
             }
 
+            IDictionary<string, OpenApiMediaType> content;
+
+            if (EntitySet.EntityType().HasStream)
+            {
+                // Support creating a media entity
+                content = new Dictionary<string, OpenApiMediaType>
+                {
+                    {
+                        // TODO: Read the AcceptableMediaType annotation from CSDL
+                        Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
+                        {
+                            Schema = schema
+                        }
+                    }
+                };
+            }
+            else
+            {
+                content = new Dictionary<string, OpenApiMediaType>
+                {
+                    {
+                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
+                        {
+                            Schema = schema
+                        }
+                    }
+                };
+            }
+
             operation.Responses = new OpenApiResponses
             {
                 {
@@ -111,16 +161,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     new OpenApiResponse
                     {
                         Description = "Created entity",
-                        Content = new Dictionary<string, OpenApiMediaType>
-                        {
-                            {
-                                Constants.ApplicationJsonMediaType,
-                                new OpenApiMediaType
-                                {
-                                    Schema = schema
-                                }
-                            }
-                        }
+                        Content = content
                     }
                 }
             };

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -58,22 +58,6 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetResponses(OpenApiOperation operation)
         {
-            OpenApiSchema schema = null;
-
-            if (Context.Settings.EnableDerivedTypesReferencesForResponses)
-            {
-                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
-            }
-
-            if (schema == null)
-            {
-                schema = new OpenApiSchema
-                {
-                    Type = "string",
-                    Format = "binary"
-                };
-            }
-
             operation.Responses = new OpenApiResponses
             {
                 {
@@ -87,7 +71,11 @@ namespace Microsoft.OpenApi.OData.Operation
                                 Constants.ApplicationOctetStreamMediaType,
                                 new OpenApiMediaType
                                 {
-                                    Schema = schema
+                                    Schema = new OpenApiSchema
+                                    {
+                                        Type = "string",
+                                        Format = "binary"
+                                    }
                                 }
                             }
                         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OpenApi.OData.Operation
     /// <summary>
     /// Retrieve a media content for an Entity
     /// </summary>
-    internal class MediaEntityGetOperationHandler : EntitySetOperationHandler
+    internal class MediaEntityGetOperationHandler : MediaEntityOperationalHandler
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Get;
@@ -25,16 +25,31 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
-            string typeName = EntitySet.EntityType().Name;
-
             // Summary
-            operation.Summary = $"Get media content for {typeName} from {EntitySet.Name}";
+            if (EntitySet != null)
+            {
+                string typeName = EntitySet.EntityType().Name;
+                operation.Summary = $"Get media content for {typeName} from {EntitySet.Name}";
+            }
+            else
+            {
+                operation.Summary = $"Get media content for the navigation property {NavigationProperty.Name} from {NavigationSource.Name}";
+            }
 
             // OperationId
             if (Context.Settings.EnableOperationId)
             {
                 string identifier = Path.LastSegment.Kind == ODataSegmentKind.StreamContent ? "Content" : Path.LastSegment.Identifier;
-                operation.OperationId = EntitySet.Name + "." + typeName + ".Get" + Utils.UpperFirstChar(identifier);
+
+                if (EntitySet != null)
+                {
+                    string typeName = EntitySet.EntityType().Name;
+                    operation.OperationId = $"{EntitySet.Name}.{typeName}.Get{Utils.UpperFirstChar(identifier)}";
+                }
+                else // Singleton
+                {
+                    operation.OperationId = GetOperationId("Get", identifier);
+                }
             }
 
             base.SetBasicInfo(operation);
@@ -86,7 +101,9 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetSecurity(OpenApiOperation operation)
         {
-            ReadRestrictionsType read = Context.Model.GetRecord<ReadRestrictionsType>(EntitySet, CapabilitiesConstants.ReadRestrictions);
+            ReadRestrictionsType read = EntitySet != null
+                ? Context.Model.GetRecord<ReadRestrictionsType>(EntitySet, CapabilitiesConstants.ReadRestrictions)
+                : Context.Model.GetRecord<ReadRestrictionsType>(Singleton, CapabilitiesConstants.ReadRestrictions);
             if (read == null)
             {
                 return;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
@@ -1,0 +1,114 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
+using Microsoft.OpenApi.OData.Edm;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.OpenApi.OData.Operation
+{
+    /// <summary>
+    /// Base class for operation of media entity.
+    /// </summary>
+    internal abstract class MediaEntityOperationalHandler : NavigationPropertyOperationHandler
+    {
+        /// <summary>
+        /// Gets/sets the <see cref="IEdmEntitySet"/>.
+        /// </summary>
+        protected IEdmEntitySet EntitySet { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="IEdmSingleton"/>.
+        /// </summary>
+        protected IEdmSingleton Singleton { get; private set; }
+
+        /// <inheritdoc/>
+        protected override void Initialize(ODataContext context, ODataPath path)
+        {
+            // The first segment will either be an entity set navigation source or a singleton navigation source.
+            ODataNavigationSourceSegment navigationSourceSegment = path.FirstSegment as ODataNavigationSourceSegment;
+            EntitySet = navigationSourceSegment.NavigationSource as IEdmEntitySet;
+
+            if (EntitySet == null)
+            {
+                // Singleton
+                base.Initialize(context, path);
+                Singleton = NavigationSource as IEdmSingleton;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void SetTags(OpenApiOperation operation)
+        {
+            if (EntitySet == null)
+            {
+                // Singleton
+                base.SetTags(operation);
+            }
+            else // Entityset
+            {
+                string tagIdentifier = EntitySet.Name + "." + EntitySet.EntityType().Name;
+
+                OpenApiTag tag = new OpenApiTag
+                {
+                    Name = tagIdentifier
+                };
+
+                // Use an extension for TOC (Table of Content)
+                tag.Extensions.Add(Constants.xMsTocType, new OpenApiString("page"));
+
+                operation.Tags.Add(tag);
+
+                Context.AppendTag(tag);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void SetExtensions(OpenApiOperation operation)
+        {
+            base.SetExtensions(operation);
+        }
+
+        /// <summary>
+        /// Retrieves the operation Id for a navigation property stream path.
+        /// </summary>
+        /// <param name="prefix">The http method identifier name.</param>
+        /// <param name="identifier">The stream segment identifier name.</param>
+        /// <returns></returns>
+        protected string GetOperationId(string prefix, string identifier)
+        {
+            Utils.CheckArgumentNull(prefix, nameof(prefix));
+            Utils.CheckArgumentNull(identifier, nameof(identifier));
+
+            IList<string> items = new List<string>
+            {
+                NavigationSource.Name
+            };
+
+            var lastpath = Path.Segments.Last(c => c is ODataStreamContentSegment || c is ODataStreamPropertySegment);
+            foreach (var segment in Path.Segments.Skip(1))
+            {
+                if (segment == lastpath)
+                {
+                    items.Add(prefix + Utils.UpperFirstChar(identifier));
+                    break;
+                }
+                else
+                {
+                    if (segment is ODataNavigationPropertySegment npSegment)
+                    {
+                        items.Add(npSegment.NavigationProperty.Name);
+                    }
+                }
+            }
+
+            return string.Join(".", items);
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -58,22 +58,6 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetRequestBody(OpenApiOperation operation)
         {
-            OpenApiSchema schema = null;
-
-            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
-            {
-                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
-            }
-
-            if (schema == null)
-            {
-                schema = new OpenApiSchema
-                {
-                    Type = "string",
-                    Format = "binary"
-                };
-            }
-
             operation.RequestBody = new OpenApiRequestBody
             {
                 Required = true,
@@ -83,7 +67,11 @@ namespace Microsoft.OpenApi.OData.Operation
                     {
                         Constants.ApplicationOctetStreamMediaType, new OpenApiMediaType
                         {
-                            Schema = schema
+                            Schema = new OpenApiSchema
+                            {
+                                Type = "string",
+                                Format = "binary"
+                            }
                         }
                     }
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OpenApi.OData.Operation
     /// <summary>
     /// Update a media content for an Entity
     /// </summary>
-    internal class MediaEntityPutOperationHandler : EntitySetOperationHandler
+    internal class MediaEntityPutOperationHandler : MediaEntityOperationalHandler
     {
         /// <inheritdoc/>
         public override OperationType OperationType => OperationType.Put;
@@ -25,16 +25,31 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
-            string typeName = EntitySet.EntityType().Name;
-
             // Summary
-            operation.Summary = $"Update media content for {typeName} in {EntitySet.Name}";
+            if (EntitySet != null)
+            {
+                string typeName = EntitySet.EntityType().Name;
+                operation.Summary = $"Update media content for {typeName} in {EntitySet.Name}";
+            }
+            else
+            {
+                operation.Summary = $"Update media content for the navigation property {NavigationProperty.Name} in {NavigationSource.Name}";
+            }
 
             // OperationId
             if (Context.Settings.EnableOperationId)
             {
                 string identifier = Path.LastSegment.Kind == ODataSegmentKind.StreamContent ? "Content" : Path.LastSegment.Identifier;
-                operation.OperationId = EntitySet.Name + "." + typeName + ".Update" + Utils.UpperFirstChar(identifier);
+
+                if (EntitySet != null)
+                {
+                    string typeName = EntitySet.EntityType().Name;
+                    operation.OperationId = $"{EntitySet.Name}.{typeName}.Update{Utils.UpperFirstChar(identifier)}";
+                }
+                else
+                {
+                    operation.OperationId = GetOperationId("Update", identifier);
+                }
             }
 
             base.SetBasicInfo(operation);
@@ -92,7 +107,9 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetSecurity(OpenApiOperation operation)
         {
-            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions);
+            UpdateRestrictionsType update = EntitySet != null
+                ? Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet, CapabilitiesConstants.UpdateRestrictions)
+                : Context.Model.GetRecord<UpdateRestrictionsType>(Singleton, CapabilitiesConstants.UpdateRestrictions);
             if (update == null || update.Permissions == null)
             {
                 return;

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -58,6 +58,25 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetRequestBody(OpenApiOperation operation)
         {
+            OpenApiSchema schema = null;
+
+            if (Context.Settings.EnableDerivedTypesReferencesForRequestBody)
+            {
+                schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
+            }
+
+            if (schema == null)
+            {
+                schema = new OpenApiSchema
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = EntitySet != null ? EntitySet.EntityType().FullName() : Singleton.EntityType().FullName()
+                    }
+                };
+            }
+
             operation.RequestBody = new OpenApiRequestBody
             {
                 Required = true,
@@ -72,6 +91,13 @@ namespace Microsoft.OpenApi.OData.Operation
                                 Type = "string",
                                 Format = "binary"
                             }
+                        }
+                    },
+                    {
+                        Constants.ApplicationJsonMediaType,
+                        new OpenApiMediaType
+                        {
+                            Schema = schema
                         }
                     }
                 }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -94,8 +94,7 @@ namespace Microsoft.OpenApi.OData.Operation
                         }
                     },
                     {
-                        Constants.ApplicationJsonMediaType,
-                        new OpenApiMediaType
+                        Constants.ApplicationJsonMediaType, new OpenApiMediaType
                         {
                             Schema = schema
                         }

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
@@ -62,7 +62,8 @@ namespace Microsoft.OpenApi.OData.Operation
             NavigationProperty = path.OfType<ODataNavigationPropertySegment>().Last().NavigationProperty;
 
             NavigationPropertyPath = string.Join("/",
-                Path.Segments.Where(s => !(s is ODataKeySegment || s is ODataNavigationSourceSegment)).Select(e => e.Identifier));
+                Path.Segments.Where(s => !(s is ODataKeySegment || s is ODataNavigationSourceSegment
+                                        || s is ODataStreamContentSegment || s is ODataStreamPropertySegment)).Select(e => e.Identifier));
 
             IEdmEntitySet entitySet = NavigationSource as IEdmEntitySet;
             IEdmSingleton singleton = NavigationSource as IEdmSingleton;
@@ -115,7 +116,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     }
                 }
             }
-            
+
             string name = string.Join(".", items);
             OpenApiTag tag = new OpenApiTag
             {

--- a/src/Microsoft.OpenApi.OData.Reader/PathItem/MediaEntityPathItemHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/PathItem/MediaEntityPathItemHandler.cs
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
+using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Vocabulary.Capabilities;
@@ -12,15 +13,28 @@ namespace Microsoft.OpenApi.OData.PathItem
     /// <summary>
     /// Create a <see cref="OpenApiPathItem"/> for a media entity.
     /// </summary>
-    internal class MediaEntityPathItemHandler : EntitySetPathItemHandler
+    internal class MediaEntityPathItemHandler : PathItemHandler
     {
         /// <inheritdoc/>
         protected override ODataPathKind HandleKind => ODataPathKind.MediaEntity;
 
+        /// <summary>
+        /// Gets the entity set.
+        /// </summary>
+        protected IEdmEntitySet EntitySet { get; private set; }
+
+        /// <summary>
+        /// Gets the singleton.
+        /// </summary>
+        protected IEdmSingleton Singleton { get; private set; }
+
         /// <inheritdoc/>
         protected override void SetOperations(OpenApiPathItem item)
         {
-            ReadRestrictionsType read = Context.Model.GetRecord<ReadRestrictionsType>(EntitySet);
+            ReadRestrictionsType read = EntitySet != null
+                ? Context.Model.GetRecord<ReadRestrictionsType>(EntitySet)
+                : Context.Model.GetRecord<ReadRestrictionsType>(Singleton);
+
             if (read == null ||
                (read.ReadByKeyRestrictions == null && read.IsReadable) ||
                (read.ReadByKeyRestrictions != null && read.ReadByKeyRestrictions.IsReadable))
@@ -28,10 +42,28 @@ namespace Microsoft.OpenApi.OData.PathItem
                 AddOperation(item, OperationType.Get);
             }
 
-            UpdateRestrictionsType update = Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet);
+            UpdateRestrictionsType update = EntitySet != null
+                ? Context.Model.GetRecord<UpdateRestrictionsType>(EntitySet)
+                : Context.Model.GetRecord<UpdateRestrictionsType>(Singleton);
+
             if (update == null || update.IsUpdatable)
             {
                 AddOperation(item, OperationType.Put);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void Initialize(ODataContext context, ODataPath path)
+        {
+            base.Initialize(context, path);
+
+            // The first segment could be an entity set segment or a singleton segment.
+            ODataNavigationSourceSegment navigationSourceSegment = path.FirstSegment as ODataNavigationSourceSegment;
+
+            EntitySet = navigationSourceSegment.NavigationSource as IEdmEntitySet;
+            if (EntitySet == null)
+            {
+                Singleton = navigationSourceSegment.NavigationSource as IEdmSingleton;
             }
         }
     }

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Edm/ODataPathProviderTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             // Assert
             Assert.NotNull(paths);
-            Assert.Equal(4457, paths.Count());
+            Assert.Equal(4544, paths.Count());
         }
 
         [Fact]
@@ -192,7 +192,7 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
     <NavigationProperty Name=""MultipleCustomers"" Type=""Collection(NS.Customer)"" ContainsTarget=""true"" />
     <NavigationProperty Name=""SingleCustomer"" Type=""NS.Customer"" ContainsTarget=""true"" />
   </EntityType>";
-            
+
             string entitySet = @"<EntitySet Name=""Orders"" EntityType=""NS.Order"" />";
             IEdmModel model = GetEdmModel(entityType, entitySet);
             ODataPathProvider provider = new ODataPathProvider();
@@ -229,21 +229,21 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
 
             if (hasStream && !streamPropName.Equals("Content", StringComparison.OrdinalIgnoreCase))
             {
-                Assert.Equal(4, paths.Count());
-                Assert.Equal(new[] { "/Todos", "/Todos({Id})", "/Todos({Id})/$value", "/Todos({Id})/Logo" },
+                Assert.Equal(7, paths.Count());
+                Assert.Equal(new[] { "/me", "/me/photo", "/me/photo/$value", "/Todos", "/Todos({Id})", "/Todos({Id})/$value", "/Todos({Id})/Logo" },
                     paths.Select(p => p.GetPathItemName()));
             }
             else if ((hasStream && streamPropName.Equals("Content", StringComparison.OrdinalIgnoreCase)) ||
                     (!hasStream && streamPropName.Equals("Content", StringComparison.OrdinalIgnoreCase)))
             {
-                Assert.Equal(3, paths.Count());
-                Assert.Equal(new[] { "/Todos", "/Todos({Id})", "/Todos({Id})/Content" },
+                Assert.Equal(6, paths.Count());
+                Assert.Equal(new[] { "/me", "/me/photo", "/me/photo/$value", "/Todos", "/Todos({Id})", "/Todos({Id})/Content" },
                     paths.Select(p => p.GetPathItemName()));
             }
             else // !hasStream && !streamPropName.Equals("Content")
             {
-                Assert.Equal(3, paths.Count());
-                Assert.Equal(new[] { "/Todos", "/Todos({Id})", "/Todos({Id})/Logo" },
+                Assert.Equal(6, paths.Count());
+                Assert.Equal(new[] { "/me", "/me/photo", "/me/photo/$value", "/Todos", "/Todos({Id})", "/Todos({Id})/Logo"},
                     paths.Select(p => p.GetPathItemName()));
             }
         }
@@ -282,9 +282,17 @@ namespace Microsoft.OpenApi.OData.Edm.Tests
         <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
         <Property Name=""{1}"" Type=""Edm.Stream""/>
         <Property Name = ""Description"" Type = ""Edm.String"" />
-         </EntityType>
-      <EntityContainer Name =""TodoService"">
-         <EntitySet Name=""Todos"" EntityType=""microsoft.graph.Todo"" />
+      </EntityType>
+      <EntityType Name=""user"" OpenType=""true"">
+        <NavigationProperty Name = ""photo"" Type = ""microsoft.graph.profilePhoto"" ContainsTarget = ""true"" />
+      </EntityType>
+      <EntityType Name=""profilePhoto"" HasStream=""true"">
+        <Property Name = ""height"" Type = ""Edm.Int32"" />
+        <Property Name = ""width"" Type = ""Edm.Int32"" />
+      </EntityType >
+      <EntityContainer Name =""GraphService"">
+        <EntitySet Name=""Todos"" EntityType=""microsoft.graph.Todo"" />
+        <Singleton Name=""me"" Type=""microsoft.graph.user"" />
       </EntityContainer>
     </Schema>
   </edmx:DataServices>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetGetOperationHandlerTests.cs
@@ -326,12 +326,12 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             }
         }
 
-        public static IEdmModel GetEdmModel(string annotation)
+        public static IEdmModel GetEdmModel(string annotation, bool hasStream = false)
         {
             const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
   <edmx:DataServices>
     <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
-      <EntityType Name=""Customer"">
+      <EntityType Name=""Customer"" HasStream=""{0}"">
         <Key>
           <PropertyRef Name=""ID"" />
         </Key>
@@ -341,12 +341,12 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
          <EntitySet Name=""Customers"" EntityType=""NS.Customer"" />
       </EntityContainer>
       <Annotations Target=""NS.Default/Customers"">
-        {0}
+        {1}
       </Annotations>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>";
-            string modelText = string.Format(template, annotation);
+            string modelText = string.Format(template, hasStream, annotation);
 
             IEdmModel model;
             IEnumerable<EdmError> errors;

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
@@ -6,6 +6,7 @@
 using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
 using Microsoft.OpenApi.OData.Tests;
 using Xunit;
@@ -17,12 +18,14 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         private EntitySetPostOperationHandler _operationHandler = new EntitySetPostOperationHandler();
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void CreateEntitySetPostOperationReturnsCorrectOperation(bool enableOperationId)
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void CreateEntitySetPostOperationReturnsCorrectOperation(bool enableOperationId, bool hasStream)
         {
             // Arrange
-            IEdmModel model = EntitySetGetOperationHandlerTests.GetEdmModel("");
+            IEdmModel model = EntitySetGetOperationHandlerTests.GetEdmModel("", hasStream);
             IEdmEntitySet entitySet = model.EntityContainer.FindEntitySet("Customers");
             OpenApiConvertSettings settings = new OpenApiConvertSettings
             {
@@ -46,6 +49,23 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             Assert.NotNull(post.Responses);
             Assert.Equal(2, post.Responses.Count);
+
+            if (hasStream)
+            {
+                // TODO: Read the AcceptableMediaType annotation from model
+                Assert.True(post.Responses["201"].Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
+
+                Assert.NotNull(post.RequestBody);
+                // TODO: Read the AcceptableMediaType annotation from model
+                Assert.True(post.RequestBody.Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
+            }
+            else
+            {
+                Assert.True(post.Responses["201"].Content.ContainsKey(Constants.ApplicationJsonMediaType));
+
+                Assert.NotNull(post.RequestBody);
+                Assert.True(post.RequestBody.Content.ContainsKey(Constants.ApplicationJsonMediaType));
+            }
 
             if (enableOperationId)
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
@@ -58,6 +58,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 Assert.NotNull(post.RequestBody);
                 // TODO: Read the AcceptableMediaType annotation from model
                 Assert.True(post.RequestBody.Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
+                Assert.True(post.RequestBody.Content.ContainsKey(Constants.ApplicationJsonMediaType));
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/EntitySetPostOperationHandlerTests.cs
@@ -54,6 +54,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
             {
                 // TODO: Read the AcceptableMediaType annotation from model
                 Assert.True(post.Responses["201"].Content.ContainsKey(Constants.ApplicationOctetStreamMediaType));
+                Assert.True(post.Responses["201"].Content.ContainsKey(Constants.ApplicationJsonMediaType));
 
                 Assert.NotNull(post.RequestBody);
                 // TODO: Read the AcceptableMediaType annotation from model

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
         public static IEdmModel GetEdmModel()
         {
-            string modelText = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+            const string modelText = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
   <edmx:DataServices>
     <Schema Namespace=""microsoft.graph"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
       <EntityType Name=""Todo"" HasStream=""true"">

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -30,7 +30,9 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             ODataContext context = new ODataContext(model, settings);
             IEdmEntitySet todos = model.EntityContainer.FindEntitySet("Todos");
+            IEdmSingleton me = model.EntityContainer.FindSingleton("me");
             Assert.NotNull(todos);
+            Assert.NotNull(me);
 
             IEdmEntityType todo = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Todo");
             IEdmStructuralProperty sp = todo.DeclaredStructuralProperties().First(c => c.Name == "Logo");
@@ -38,33 +40,51 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 new ODataKeySegment(todos.EntityType()),
                 new ODataStreamPropertySegment(sp.Name));
 
+            IEdmEntityType user = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "user");
+            IEdmNavigationProperty navProperty = user.DeclaredNavigationProperties().First(c => c.Name == "photo");
+            ODataPath path2 = new ODataPath(new ODataNavigationSourceSegment(me),
+                new ODataNavigationPropertySegment(navProperty),
+                new ODataStreamContentSegment());
+
             // Act
             var getOperation = _operationalHandler.CreateOperation(context, path);
+            var getOperation2 = _operationalHandler.CreateOperation(context, path2);
 
             // Assert
             Assert.NotNull(getOperation);
+            Assert.NotNull(getOperation2);
             Assert.Equal("Get media content for Todo from Todos", getOperation.Summary);
+            Assert.Equal("Get media content for the navigation property photo from me", getOperation2.Summary);
             Assert.NotNull(getOperation.Tags);
+            Assert.NotNull(getOperation2.Tags);
+
             var tag = Assert.Single(getOperation.Tags);
+            var tag2 = Assert.Single(getOperation2.Tags);
             Assert.Equal("Todos.Todo", tag.Name);
+            Assert.Equal("me.profilePhoto", tag2.Name);
 
             Assert.NotNull(getOperation.Responses);
+            Assert.NotNull(getOperation2.Responses);
             Assert.Equal(2, getOperation.Responses.Count);
+            Assert.Equal(2, getOperation2.Responses.Count);
             Assert.Equal(new[] { "200", "default" }, getOperation.Responses.Select(r => r.Key));
+            Assert.Equal(new[] { "200", "default" }, getOperation2.Responses.Select(r => r.Key));
 
             if (enableOperationId)
             {
                 Assert.Equal("Todos.Todo.GetLogo", getOperation.OperationId);
+                Assert.Equal("me.photo.GetContent", getOperation2.OperationId);
             }
             else
             {
                 Assert.Null(getOperation.OperationId);
+                Assert.Null(getOperation2.OperationId);
             }
         }
 
         public static IEdmModel GetEdmModel()
         {
-            const string modelText = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+            string modelText = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
   <edmx:DataServices>
     <Schema Namespace=""microsoft.graph"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
       <EntityType Name=""Todo"" HasStream=""true"">
@@ -74,9 +94,17 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
         <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
         <Property Name=""Logo"" Type=""Edm.Stream""/>
         <Property Name = ""Description"" Type = ""Edm.String"" />
-         </EntityType>
-      <EntityContainer Name =""TodoService"">
-         <EntitySet Name=""Todos"" EntityType=""microsoft.graph.Todo"" />
+      </EntityType>
+      <EntityType Name=""user"" OpenType=""true"">
+        <NavigationProperty Name = ""photo"" Type = ""microsoft.graph.profilePhoto"" ContainsTarget = ""true"" />
+      </EntityType>
+      <EntityType Name=""profilePhoto"" HasStream=""true"">
+        <Property Name = ""height"" Type = ""Edm.Int32"" />
+        <Property Name = ""width"" Type = ""Edm.Int32"" />
+      </EntityType >
+      <EntityContainer Name =""GraphService"">
+        <EntitySet Name=""Todos"" EntityType=""microsoft.graph.Todo"" />
+        <Singleton Name=""me"" Type=""microsoft.graph.user"" />
       </EntityContainer>
     </Schema>
   </edmx:DataServices>

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             ODataContext context = new ODataContext(model, settings);
             IEdmEntitySet todos = model.EntityContainer.FindEntitySet("Todos");
+            IEdmSingleton me = model.EntityContainer.FindSingleton("me");
             Assert.NotNull(todos);
 
             IEdmEntityType todo = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Todo");
@@ -36,27 +37,45 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
                 new ODataKeySegment(todos.EntityType()),
                 new ODataStreamPropertySegment(sp.Name));
 
+            IEdmEntityType user = model.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "user");
+            IEdmNavigationProperty navProperty = user.DeclaredNavigationProperties().First(c => c.Name == "photo");
+            ODataPath path2 = new ODataPath(new ODataNavigationSourceSegment(me),
+                new ODataNavigationPropertySegment(navProperty),
+                new ODataStreamContentSegment());
+
             // Act
             var getOperation = _operationalHandler.CreateOperation(context, path);
+            var getOperation2 = _operationalHandler.CreateOperation(context, path2);
 
             // Assert
             Assert.NotNull(getOperation);
+            Assert.NotNull(getOperation2);
             Assert.Equal("Update media content for Todo in Todos", getOperation.Summary);
+            Assert.Equal("Update media content for the navigation property photo in me", getOperation2.Summary);
             Assert.NotNull(getOperation.Tags);
+            Assert.NotNull(getOperation2.Tags);
+
             var tag = Assert.Single(getOperation.Tags);
+            var tag2 = Assert.Single(getOperation2.Tags);
             Assert.Equal("Todos.Todo", tag.Name);
+            Assert.Equal("me.profilePhoto", tag2.Name);
 
             Assert.NotNull(getOperation.Responses);
+            Assert.NotNull(getOperation2.Responses);
             Assert.Equal(2, getOperation.Responses.Count);
+            Assert.Equal(2, getOperation2.Responses.Count);
             Assert.Equal(new[] { "204", "default" }, getOperation.Responses.Select(r => r.Key));
+            Assert.Equal(new[] { "204", "default" }, getOperation2.Responses.Select(r => r.Key));
 
             if (enableOperationId)
             {
                 Assert.Equal("Todos.Todo.UpdateLogo", getOperation.OperationId);
+                Assert.Equal("me.photo.UpdateContent", getOperation2.OperationId);
             }
             else
             {
                 Assert.Null(getOperation.OperationId);
+                Assert.Null(getOperation2.OperationId);
             }
         }
     }


### PR DESCRIPTION
Closes: https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_workitems/edit/5853/

**Proposes:**
- Adding support for creating a media entity through a `POST` to the media entity's entity set.
- Updating the relevant tests to validate the above support.

NB: `Content-Type` of `application/octet-stream` has been used in the `Content` payloads of the `RequestBody` and `Response` of the POST operation. This is temporary and there is a [To-Do task](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_workitems/edit/5854/) that will create support for reading the acceptable media types from the vocabulary annotations in the CSDL.