### PR TITLE
Fix: Updates media entities Operation Ids

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -25,30 +25,21 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             // Summary
-            if (EntitySet != null)
+            if (IsNavigationPropertyPath)
             {
-                string typeName = EntitySet.EntityType().Name;
-                operation.Summary = $"Get media content for {typeName} from {EntitySet.Name}";
+                operation.Summary = $"Get media content for the navigation property {NavigationProperty.Name} from {NavigationSource.Name}";
             }
             else
             {
-                operation.Summary = $"Get media content for the navigation property {NavigationProperty.Name} from {NavigationSource.Name}";
+                string typeName = EntitySet.EntityType().Name;
+                operation.Summary = $"Get media content for {typeName} from {EntitySet.Name}";
             }
 
             // OperationId
             if (Context.Settings.EnableOperationId)
             {
                 string identifier = Path.LastSegment.Kind == ODataSegmentKind.StreamContent ? "Content" : Path.LastSegment.Identifier;
-
-                if (EntitySet != null)
-                {
-                    string typeName = EntitySet.EntityType().Name;
-                    operation.OperationId = $"{EntitySet.Name}.{typeName}.Get{Utils.UpperFirstChar(typeName)}{Utils.UpperFirstChar(identifier)}";
-                }
-                else // Singleton
-                {
-                    operation.OperationId = GetOperationId("Get", identifier);
-                }
+                operation.OperationId = GetOperationId("Get", identifier);
             }
 
             base.SetBasicInfo(operation);

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityGetOperationHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 if (EntitySet != null)
                 {
                     string typeName = EntitySet.EntityType().Name;
-                    operation.OperationId = $"{EntitySet.Name}.{typeName}.Get{Utils.UpperFirstChar(identifier)}";
+                    operation.OperationId = $"{EntitySet.Name}.{typeName}.Get{Utils.UpperFirstChar(typeName)}{Utils.UpperFirstChar(identifier)}";
                 }
                 else // Singleton
                 {

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
@@ -30,18 +30,31 @@ namespace Microsoft.OpenApi.OData.Operation
         /// </summary>
         protected IEdmSingleton Singleton { get; private set; }
 
+        /// <summary>
+        /// Gets/Sets flag indicating whether path is navigation property path
+        /// </summary>
+        protected bool IsNavigationPropertyPath { get; private set; }
+
         /// <inheritdoc/>
         protected override void Initialize(ODataContext context, ODataPath path)
         {
-            // The first segment will either be an entity set navigation source or a singleton navigation source.
+            // The first segment will either be an EntitySet navigation source or a Singleton navigation source
             ODataNavigationSourceSegment navigationSourceSegment = path.FirstSegment as ODataNavigationSourceSegment;
             EntitySet = navigationSourceSegment.NavigationSource as IEdmEntitySet;
 
             if (EntitySet == null)
             {
-                // Singleton
+                Singleton = navigationSourceSegment.NavigationSource as IEdmSingleton;
+            }
+
+            // Check whether path is a navigation property path
+            IsNavigationPropertyPath = Path.Segments.Contains(
+                Path.Segments.Where(segment => segment is ODataNavigationPropertySegment).FirstOrDefault());
+
+            if (IsNavigationPropertyPath)
+            {
+                // Initialize navigation property paths from base
                 base.Initialize(context, path);
-                Singleton = NavigationSource as IEdmSingleton;
             }
         }
 
@@ -78,7 +91,7 @@ namespace Microsoft.OpenApi.OData.Operation
         }
 
         /// <summary>
-        /// Retrieves the operation Id for a navigation property stream path.
+        /// Retrieves the operation Id for a media entity stream path.
         /// </summary>
         /// <param name="prefix">The http method identifier name.</param>
         /// <param name="identifier">The stream segment identifier name.</param>
@@ -90,7 +103,7 @@ namespace Microsoft.OpenApi.OData.Operation
 
             IList<string> items = new List<string>
             {
-                NavigationSource.Name
+                EntitySet?.Name ?? Singleton.Name
             };
 
             ODataSegment lastSegment = Path.Segments.Last(c => c is ODataStreamContentSegment || c is ODataStreamPropertySegment);
@@ -98,7 +111,19 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 if (segment == lastSegment)
                 {
-                    items.Add(prefix + Utils.UpperFirstChar(NavigationProperty.Name) + Utils.UpperFirstChar(identifier));
+                    if (!IsNavigationPropertyPath)
+                    {
+                        string typeName = EntitySet?.EntityType().Name ?? Singleton.EntityType().Name;
+                        items.Add(typeName);
+                        items.Add(prefix + Utils.UpperFirstChar(identifier));
+                    }
+                    else
+                    {
+                        // Remove the last navigation property segment for navigation property paths,
+                        // as this will be included within the prefixed name of the operation id
+                        items.Remove(NavigationProperty.Name);
+                        items.Add(prefix + Utils.UpperFirstChar(NavigationProperty.Name) + Utils.UpperFirstChar(identifier));
+                    }
                     break;
                 }
                 else

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
@@ -98,7 +98,7 @@ namespace Microsoft.OpenApi.OData.Operation
             {
                 if (segment == lastSegment)
                 {
-                    items.Add(prefix + Utils.UpperFirstChar(identifier));
+                    items.Add(prefix + Utils.UpperFirstChar(NavigationProperty.Name) + Utils.UpperFirstChar(identifier));
                     break;
                 }
                 else

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -25,30 +25,21 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetBasicInfo(OpenApiOperation operation)
         {
             // Summary
-            if (EntitySet != null)
+            if (IsNavigationPropertyPath)
             {
-                string typeName = EntitySet.EntityType().Name;
-                operation.Summary = $"Update media content for {typeName} in {EntitySet.Name}";
+                operation.Summary = $"Update media content for the navigation property {NavigationProperty.Name} in {NavigationSource.Name}";
             }
             else
             {
-                operation.Summary = $"Update media content for the navigation property {NavigationProperty.Name} in {NavigationSource.Name}";
+                string typeName = EntitySet.EntityType().Name;
+                operation.Summary = $"Update media content for {typeName} in {EntitySet.Name}";
             }
 
             // OperationId
             if (Context.Settings.EnableOperationId)
             {
                 string identifier = Path.LastSegment.Kind == ODataSegmentKind.StreamContent ? "Content" : Path.LastSegment.Identifier;
-
-                if (EntitySet != null)
-                {
-                    string typeName = EntitySet.EntityType().Name;
-                    operation.OperationId = $"{EntitySet.Name}.{typeName}.Update{Utils.UpperFirstChar(typeName)}{Utils.UpperFirstChar(identifier)}";
-                }
-                else
-                {
-                    operation.OperationId = GetOperationId("Update", identifier);
-                }
+                operation.OperationId = GetOperationId("Update", identifier);
             }
 
             base.SetBasicInfo(operation);

--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityPutOperationHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.OData.Operation
                 if (EntitySet != null)
                 {
                     string typeName = EntitySet.EntityType().Name;
-                    operation.OperationId = $"{EntitySet.Name}.{typeName}.Update{Utils.UpperFirstChar(identifier)}";
+                    operation.OperationId = $"{EntitySet.Name}.{typeName}.Update{Utils.UpperFirstChar(typeName)}{Utils.UpperFirstChar(identifier)}";
                 }
                 else
                 {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -108,8 +108,8 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Todos.Todo.GetTodoLogo", getOperation.OperationId);
-                Assert.Equal("me.photo.GetPhotoContent", getOperation2.OperationId);
+                Assert.Equal("Todos.Todo.GetLogo", getOperation.OperationId);
+                Assert.Equal("me.GetPhotoContent", getOperation2.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityGetOperationHandlerTests.cs
@@ -108,8 +108,8 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Todos.Todo.GetLogo", getOperation.OperationId);
-                Assert.Equal("me.photo.GetContent", getOperation2.OperationId);
+                Assert.Equal("Todos.Todo.GetTodoLogo", getOperation.OperationId);
+                Assert.Equal("me.photo.GetPhotoContent", getOperation2.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
@@ -105,8 +105,8 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Todos.Todo.UpdateTodoLogo", putOperation.OperationId);
-                Assert.Equal("me.photo.UpdatePhotoContent", putOperation2.OperationId);
+                Assert.Equal("Todos.Todo.UpdateLogo", putOperation.OperationId);
+                Assert.Equal("me.UpdatePhotoContent", putOperation2.OperationId);
             }
             else
             {

--- a/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
+++ b/test/Microsoft.OpenAPI.OData.Reader.Tests/Operation/MediaEntityPutOperationHandlerTests.cs
@@ -105,8 +105,8 @@ namespace Microsoft.OpenApi.OData.Operation.Tests
 
             if (enableOperationId)
             {
-                Assert.Equal("Todos.Todo.UpdateLogo", putOperation.OperationId);
-                Assert.Equal("me.photo.UpdateContent", putOperation2.OperationId);
+                Assert.Equal("Todos.Todo.UpdateTodoLogo", putOperation.OperationId);
+                Assert.Equal("me.photo.UpdatePhotoContent", putOperation2.OperationId);
             }
             else
             {


### PR DESCRIPTION
**Proposes**:
- Fixing the generation of media entity paths Operation Ids appropriately.
- Updating the relevant tests to validate the above fix.


Below are example snippets of the generated operations from the Graph v1.0 metadata:

```
/applications({id})/logo':
    get:
      tags:
        - applications.application
      summary: Get media content for application from applications
      operationId: applications.application.GetLogo
```

```
/drives({id})/items({id1})/content':
    get:
      tags:
        - drives.drive
      summary: Get media content for the navigation property items from drives
      operationId: drives.GetItemsContent
```

```
/groups({id})/onenote/pages({id1})/content:
    get:
      tags:
        - groups.group
      summary: Get media content for the navigation property pages from groups
      operationId: groups.onenote.GetPagesContent
```

A link to the OpenAPI doc. described from this change can be found from this link: https://microsoft.sharepoint-df.com/:u:/t/GraphTooling/EQMpXkl2Gq9NuyaD6Bjvix4Bq0rAk9ulinOpcswMPLQNlw?e=cc8YRK