### PR TITLE
Fix: Generates correct media entity operation tags

### DIFF
--- a/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
+++ b/src/Microsoft.OpenApi.OData.Reader/Operation/MediaEntityOperationalHandler.cs
@@ -61,12 +61,11 @@ namespace Microsoft.OpenApi.OData.Operation
         /// <inheritdoc/>
         protected override void SetTags(OpenApiOperation operation)
         {
-            if (EntitySet == null)
+            if (IsNavigationPropertyPath)
             {
-                // Singleton
                 base.SetTags(operation);
             }
-            else // Entityset
+            else
             {
                 string tagIdentifier = EntitySet.Name + "." + EntitySet.EntityType().Name;
 


### PR DESCRIPTION
**Issue**:
Operation tags for media entity navigation property paths of EntitySet navigation sources don't match their parents' tags e.g. `/users/{id}/photo/$value` tag is `users.user`, yet `/users/{id}/photo` tag is `users.profilePhoto`.

![MicrosoftTeams-image (5)](https://user-images.githubusercontent.com/40403681/96041502-998bc000-0e74-11eb-971f-a9faaaadc1d5.png)

**Fix**:
This PR appropriately fixes the condition evaluating whether a media entity path is a navigation property path when creating tags.

Below are a few snippet of the operation tags generated from this fix:

```
/users({id})/photo/$value:
    get:
      tags:
        - users.profilePhoto
      summary: Get media content for the navigation property photo from users
      operationId: users.GetPhotoContent
```
```
/users({id})/contacts({id1})/photo/$value:
    get:
      tags:
        - users.contacts.profilePhoto
      summary: Get media content for the navigation property photo from users
      operationId: users.contacts.GetPhotoContent
```
```
/groups({id})/onenote/pages({id1})/content:
    get:
      tags:
        - groups.onenote.onenotePage
      summary: Get media content for the navigation property pages from groups
      operationId: groups.onenote.GetPagesContent
```

Here's a link to the complete v1.0 OpenAPI doc. generated from this fix: https://microsoft.sharepoint-df.com/:u:/t/GraphTooling/Efkqll2yap9GloX3nPMM38YBcAd-jmAZKG3fQeKIHscghg?e=FKjVHn